### PR TITLE
fix: autodoc module resolution

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:
@@ -5,6 +8,10 @@
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+# set system path to /leqo-backend/
+sys.path.insert(0, os.path.abspath("../"))
+
 
 project = "LEQO-Backend"
 copyright = "2025, LEQO Backend Team"


### PR DESCRIPTION
To resolve an issue with autodoc not finding the `app.preprocessing` module, the parent directory of the `app` folder has been added to `sys.path` in the `conf.py` file. This allows Sphinx to correctly locate and import the module when generating documentation.

# Definition of Done

- [x] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [x] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [x] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [x] **Deployment Readiness**: The work is ready for deployment to production if needed.
