### PR TITLE
fix: error for classic input in uncompute

### DIFF
--- a/app/processing/pre/io_parser.py
+++ b/app/processing/pre/io_parser.py
@@ -277,6 +277,9 @@ class ParseAnnotationsVisitor(LeqoTransformer[None]):
             if input_id in self.__found_input_ids:
                 msg = f"Unsupported: duplicate input id: {input_id}"
                 raise IndexError(msg)
+            if self.__in_uncompute:
+                msg = f"Unsupported: input declaration over {info.name} in uncompute block"
+                raise UnsupportedOperation(msg)
             self.__found_input_ids.add(input_id)
             self.io.inputs[input_id] = info
 


### PR DESCRIPTION
Add error if input via classical declaration in uncompute block

# Definition of Done

- [x] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [x] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [x] **Peer Review**: The code has undergone peer review by another team member.
- [x] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [x] **Deployment Readiness**: The work is ready for deployment to production if needed.
