### PR TITLE
feat: rename with prefix

### DIFF
--- a/app/processing/pre/renaming.py
+++ b/app/processing/pre/renaming.py
@@ -43,9 +43,6 @@ class RenameRegisterTransformer(QASMTransformer[SectionInfo]):
         :return: A new globally unique identifier.
         """
 
-        if self.renames.get(old_identifier.name) is not None:
-            raise Exception("Variable already defined")
-
         new_identifier = Identifier(f"leqo_{context.id.hex}_{old_identifier.name}")
         self.renames[old_identifier.name] = new_identifier
 

--- a/app/processing/pre/renaming.py
+++ b/app/processing/pre/renaming.py
@@ -46,8 +46,7 @@ class RenameRegisterTransformer(QASMTransformer[SectionInfo]):
         if self.renames.get(old_identifier.name) is not None:
             raise Exception("Variable already defined")
 
-        index = len(self.renames)
-        new_identifier = Identifier(f"leqo_{context.id.hex}_declaration{index}")
+        new_identifier = Identifier(f"leqo_{context.id.hex}_{old_identifier.name}")
         self.renames[old_identifier.name] = new_identifier
 
         return new_identifier
@@ -156,7 +155,6 @@ class RenameRegisterTransformer(QASMTransformer[SectionInfo]):
     def visit_Identifier(self, node: Identifier, _context: SectionInfo) -> Identifier:
         """
         Renames identifiers using the old declaration names.
-        ToDo: We currently ignore scope!!
 
         :param node: Identifier to rename
         :return: Modified identifier

--- a/tests/processing/merge/test_init.py
+++ b/tests/processing/merge/test_init.py
@@ -48,7 +48,7 @@ def test_pseudo_merge_single() -> None:
     OPENQASM 3.1;
     qubit[1] leqo_reg;
     /* Start node 0 */
-    let leqo_node0_declaration0 = leqo_reg[{0}];
+    let leqo_node0_a = leqo_reg[{0}];
     /* End node 0 */
     """
     assert_merge(codes, connections, expected)
@@ -73,13 +73,13 @@ def test_merge_two_nodes() -> None:
     OPENQASM 3.1;
     qubit[1] leqo_reg;
     /* Start node 0 */
-    let leqo_node0_declaration0 = leqo_reg[{0}];
+    let leqo_node0_a = leqo_reg[{0}];
     @leqo.output 0
-    let leqo_node0_declaration1 = leqo_node0_declaration0;
+    let leqo_node0__out = leqo_node0_a;
     /* End node 0 */
     /* Start node 1 */
     @leqo.input 0
-    let leqo_node1_declaration0 = leqo_reg[{0}];
+    let leqo_node1_a = leqo_reg[{0}];
     /* End node 1 */
     """
     assert_merge(codes, connections, expected)
@@ -119,23 +119,23 @@ def test_complex_merge() -> None:
     OPENQASM 3.1;
     qubit[4] leqo_reg;
     /* Start node 0 */
-    let leqo_node0_declaration0 = leqo_reg[{0, 1, 2, 3}];
+    let leqo_node0_q = leqo_reg[{0, 1, 2, 3}];
     @leqo.output 0
-    let leqo_node0_declaration1 = leqo_node0_declaration0[0:2];
+    let leqo_node0__out0 = leqo_node0_q[0:2];
     @leqo.output 1
-    let leqo_node0_declaration2 = leqo_node0_declaration0[3];
+    let leqo_node0__out1 = leqo_node0_q[3];
     /* End node 0 */
     /* Start node 1 */
     @leqo.input 0
-    let leqo_node1_declaration0 = leqo_reg[{3}];
+    let leqo_node1_q = leqo_reg[{3}];
     @leqo.output 0
-    let leqo_node1_declaration1 = leqo_node1_declaration0;
+    let leqo_node1__out0 = leqo_node1_q;
     /* End node 1 */
     /* Start node 2 */
     @leqo.input 0
-    let leqo_node2_declaration0 = leqo_reg[{3}];
+    let leqo_node2_q0 = leqo_reg[{3}];
     @leqo.input 1
-    let leqo_node2_declaration1 = leqo_reg[{0, 1, 2}];
+    let leqo_node2_q1 = leqo_reg[{0, 1, 2}];
     /* End node 2 */
     """
     assert_merge(codes, connections, expected)

--- a/tests/processing/pre/test_renaming.py
+++ b/tests/processing/pre/test_renaming.py
@@ -26,7 +26,7 @@ def test_register_renaming() -> None:
         @leqo.input 5
         qubit[3] q3;
         @leqo.input 6
-        qubit leqo_{id.hex}_declaration1;
+        qubit leqo_{id.hex}_f1;
         @leqo.input 7
         let alias = q1_2;
         @leqo.input 8
@@ -37,34 +37,34 @@ def test_register_renaming() -> None:
         x q1_2;
         x q2;
         x q3;
-        x leqo_{id.hex}_declaration1;
+        x leqo_{id.hex}_f1;
         """,
         f"""\
         OPENQASM 3;
         @leqo.input 0
-        float leqo_{id.hex}_declaration0;
+        float leqo_{id.hex}_f1;
         @leqo.input 1
-        float leqo_{id.hex}_declaration1;
+        float leqo_{id.hex}_f2;
         @leqo.input 2
-        qubit leqo_{id.hex}_declaration2;
+        qubit leqo_{id.hex}_q1;
         @leqo.input 3
-        qubit[1] leqo_{id.hex}_declaration3;
+        qubit[1] leqo_{id.hex}_q1_2;
         @leqo.input 4
-        qubit[2] leqo_{id.hex}_declaration4;
+        qubit[2] leqo_{id.hex}_q2;
         @leqo.input 5
-        qubit[3] leqo_{id.hex}_declaration5;
+        qubit[3] leqo_{id.hex}_q3;
         @leqo.input 6
-        qubit leqo_{id.hex}_declaration6;
+        qubit leqo_{id.hex}_leqo_{id.hex}_f1;
         @leqo.input 7
-        let leqo_{id.hex}_declaration7 = leqo_{id.hex}_declaration3;
+        let leqo_{id.hex}_alias = leqo_{id.hex}_q1_2;
         @leqo.input 8
-        bit leqo_{id.hex}_declaration8 = leqo_{id.hex}_declaration3;
+        bit leqo_{id.hex}_classicalTest = leqo_{id.hex}_q1_2;
         @leqo.input 9
-        const bit leqo_{id.hex}_declaration9 = measure leqo_{id.hex}_declaration3;
-        x leqo_{id.hex}_declaration2;
-        x leqo_{id.hex}_declaration3;
-        x leqo_{id.hex}_declaration4;
-        x leqo_{id.hex}_declaration5;
-        x leqo_{id.hex}_declaration6;
+        const bit leqo_{id.hex}_classicalTest2 = measure leqo_{id.hex}_q1_2;
+        x leqo_{id.hex}_q1;
+        x leqo_{id.hex}_q1_2;
+        x leqo_{id.hex}_q2;
+        x leqo_{id.hex}_q3;
+        x leqo_{id.hex}_leqo_{id.hex}_f1;
         """,
     )


### PR DESCRIPTION
Implement idea by @len-01:
Instead of completly renaming declarations it's better to only prefix them.
This way we still get global unique identifiers but also don't have to handle overloading and scoping.

Adding a valid identifier as prefix will result in a valid identifier:
https://github.com/openqasm/openqasm/blob/015ac66b5f935a8b3cebc295d4461e4260a5b92f/source/grammar/qasm3Lexer.g4#L137-L143

# Definition of Done

- [x] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [x] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [x] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [x] **Deployment Readiness**: The work is ready for deployment to production if needed.
