### PR TITLE
fix: small fix for dto

### DIFF
--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -39,12 +39,11 @@ class ImplementationNode(_BaseNode):
 class EncodeValueNode(_BaseNode):
     type: Literal["encode"] = "encode"
     encoding: Literal["amplitude", "angle", "basis", "custom", "matrix", "schmidt"]
-    bounds: int = Field(ge=1)
+    bounds: int = Field(ge=0)
 
 
 class PrepareStateNode(_BaseNode):
     type: Literal["prepare"] = "prepare"
-    size: int = Field(ge=1)
     quantumState: Literal["ϕ+", "ϕ-", "ψ+", "ψ-", "custom", "ghz", "uniform", "w"]
 
 
@@ -146,7 +145,6 @@ class OperatorNode(_BaseNode):
         "!=",
         "min",
         "max",
-        "search",
     ]
 
 
@@ -170,7 +168,6 @@ class _EdgeBase(BaseModel):
 
 class QubitEdge(_EdgeBase):
     type: Literal["qubit"]
-    size: int = Field(1, ge=1)
 
 
 class ClassicalEdge(_EdgeBase):
@@ -179,7 +176,6 @@ class ClassicalEdge(_EdgeBase):
 
 class AncillaEdge(_EdgeBase):
     type: Literal["ancilla"]
-    size: int = Field(1, ge=1)
 
 
 Edge = QubitEdge | ClassicalEdge | AncillaEdge


### PR DESCRIPTION
### Nodes
- `EncodeValueNode`.`bounds` should allow `0`
- `PrepareStateNode` does not have `size`
- Remove `search` from operators as we need a more special node later

### Edges
- Edges no longer have a size as it will be calculated by the backend during enrichment

# Definition of Done

- [x] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [x] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [x] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [x] **Deployment Readiness**: The work is ready for deployment to production if needed.
