### PR TITLE
feat: dto for nested nodes

### DIFF
--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -3,6 +3,8 @@ This module defines the data models for compile requests.
 It provides classes to model metadata, node data, and the complete compile request.
 """
 
+from __future__ import annotations
+
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
@@ -17,8 +19,8 @@ class MetaData(BaseModel):
     name: str
     description: str
     author: str
-    optimizeWidth: Annotated[int, Field(ge=0)] | None = None
-    optimizeDepth: Annotated[int, Field(ge=0)] | None = None
+    optimizeWidth: Annotated[int, Field(gt=0)] | None = None
+    optimizeDepth: Annotated[int, Field(gt=0)] | None = None
 
 
 class _BaseNode(BaseModel):
@@ -31,6 +33,11 @@ class _BaseNode(BaseModel):
 
 
 class ImplementationNode(_BaseNode):
+    """
+    Special node that holds just an implementation.
+    This is used in case the user manually enters an implementation in the frontend.
+    """
+
     type: Literal["implementation"] = "implementation"
     implementation: str
 
@@ -39,12 +46,13 @@ class ImplementationNode(_BaseNode):
 class EncodeValueNode(_BaseNode):
     type: Literal["encode"] = "encode"
     encoding: Literal["amplitude", "angle", "basis", "custom", "matrix", "schmidt"]
-    bounds: int = Field(ge=0)
+    bounds: int = Field(ge=0, default=0, le=1)
 
 
 class PrepareStateNode(_BaseNode):
     type: Literal["prepare"] = "prepare"
     quantumState: Literal["ϕ+", "ϕ-", "ψ+", "ψ-", "custom", "ghz", "uniform", "w"]
+    size: int = Field(gt=0)
 
 
 class SplitterNode(_BaseNode):
@@ -68,7 +76,6 @@ BoundaryNode = (
 # endregion
 
 
-# region Circuit Nodes
 class QubitNode(_BaseNode):
     type: Literal["qubit"] = "qubit"
     size: int = Field(default=1, ge=1)
@@ -76,11 +83,13 @@ class QubitNode(_BaseNode):
 
 class GateNode(_BaseNode):
     type: Literal["gate"] = "gate"
-    gate: Literal["cnot", "toffoli", "h", "rx", "ry", "rz", "x", "y", "z"]
+    gate: Literal["cnot", "toffoli", "h", "x", "y", "z"]
 
 
-CircuitNode = QubitNode | GateNode
-# endregion
+class ParameterizedGateNode(_BaseNode):
+    type: Literal["gate-with-param"] = "gate-with-param"
+    gate: Literal["rx", "ry", "rz"]
+    parameter: float
 
 
 # region Literals
@@ -106,37 +115,38 @@ class FloatLiteralNode(_BaseNode):
     value: float
 
 
-class AncillaLiteralNode(_BaseNode):
+LiteralNode = BitLiteralNode | BoolLiteralNode | IntLiteralNode | FloatLiteralNode
+# endregion
+
+
+class AncillaNode(_BaseNode):
     type: Literal["ancilla"] = "ancilla"
     size: int = Field(default=1, ge=1)
 
 
-LiteralNode = (
-    BitLiteralNode
-    | BoolLiteralNode
-    | IntLiteralNode
-    | FloatLiteralNode
-    | AncillaLiteralNode
-)
-# endregion
-
-
 # region ControlFlow
+class NestedBlock(BaseModel):
+    nodes: list[NestableNode]
+    edges: list[Edge]
+
+
 class IfThenElseNode(_BaseNode):
     type: Literal["if-then-else"] = "if-then-else"
-    # ToDo: Specify if-block
+    condition: str
+    thenBlock: NestedBlock
+    elseBlock: NestedBlock
 
 
 class RepeatNode(_BaseNode):
     type: Literal["repeat"] = "repeat"
-    # ToDo: Specify repeat block
+    iterations: int = Field(gt=0)
+    block: NestedBlock
 
 
 ControlFlowNode = IfThenElseNode | RepeatNode
 # endregion
 
 
-# region Operator
 class OperatorNode(_BaseNode):
     type: Literal["operator"] = "operator"
     operator: Literal[
@@ -160,38 +170,25 @@ class OperatorNode(_BaseNode):
     ]
 
 
-# endregion
-
-Node = (
+NestableNode = (
     ImplementationNode
+    | QubitNode
     | BoundaryNode
-    | CircuitNode
+    | GateNode
+    | ParameterizedGateNode
     | LiteralNode
+    | AncillaNode
     | ControlFlowNode
     | OperatorNode
 )
+Node = NestableNode | QubitNode
 
 
-# region Edges
-class _EdgeBase(BaseModel):
+class Edge(BaseModel):
     source: tuple[str, Annotated[int, Field(ge=0)]]
     target: tuple[str, Annotated[int, Field(ge=0)]]
-
-
-class QubitEdge(_EdgeBase):
-    type: Literal["qubit"]
-
-
-class ClassicalEdge(_EdgeBase):
-    type: Literal["classical"]
-
-
-class AncillaEdge(_EdgeBase):
-    type: Literal["ancilla"]
-
-
-Edge = QubitEdge | ClassicalEdge | AncillaEdge
-# endregion
+    size: int | None = None
+    identifier: str | None = None
 
 
 class CompileRequest(BaseModel):
@@ -201,4 +198,4 @@ class CompileRequest(BaseModel):
 
     metadata: MetaData
     nodes: list[Annotated[Node, Field(discriminator="type")]]
-    edges: list[Annotated[Edge, Field(discriminator="type")]]
+    edges: list[Edge]

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -172,16 +172,14 @@ class OperatorNode(_BaseNode):
 
 NestableNode = (
     ImplementationNode
-    | QubitNode
     | BoundaryNode
     | GateNode
     | ParameterizedGateNode
     | LiteralNode
     | AncillaNode
-    | ControlFlowNode
     | OperatorNode
 )
-Node = NestableNode | QubitNode
+Node = NestableNode | QubitNode | ControlFlowNode
 
 
 class Edge(BaseModel):


### PR DESCRIPTION
Added nested nodes and some further fixes for dto

### Additions
- `NestableNode` vs `Node`
- Defined `NestedBlock`
- Specified `IfThenElseNode`
- Specified `RepeatNode`
- Edges can now take `identifier` and `size`

### Breaking changes
- `AncillaNode` renamed and is no longer a `LiteralNode`
- Removed `CircuitNode`
- Split `ParameterizedGateNode` from `GateNode`
- Removed edge types

# Definition of Done

- [x] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [x] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [x] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [x] **Deployment Readiness**: The work is ready for deployment to production if needed.
