### PR TITLE
fix(enricher): handle empty result without exceptions

### DIFF
--- a/app/enricher/__init__.py
+++ b/app/enricher/__init__.py
@@ -195,6 +195,9 @@ class Enricher:
                 exceptions.append(ex)
 
         if len(results) == 0:
+            if len(exceptions) == 0:
+                raise Exception(f"No implementations were found for node '{node.id}'")
+
             raise ExceptionGroup(f"Enrichment for node '{node.id}' failed", exceptions)
 
         key_selector: Callable[[EnrichmentResult], tuple[int | float, int | float]]


### PR DESCRIPTION
Before #153 enricher strategies used to throw a `NodeUnsupportedException` in case they were tasked to enrich an unknown node. Now they can simply return an empty list for improved performance.

With the old behavior: `len(results) == 0` <=> `len(exceptions) > 0`   
But now it's possible to get no results without exceptions in the enricher.

All exceptions from the strategies were grouped in an `ExceptionGroup` but the constructor of `ExceptionGroup` does not allow an empty list of exceptions.

To fix this: We now through a different exception to handle this edge-case.

# Definition of Done

- [x] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [x] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [x] **Peer Review**: The code has undergone peer review by another team member.
- [x] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [x] **Deployment Readiness**: The work is ready for deployment to production if needed.
