### PR TITLE
fix: don't throw `NodeUnsupportedException` in `LiteralEnricherStrategy`

### DIFF
--- a/app/enricher/literals.py
+++ b/app/enricher/literals.py
@@ -27,7 +27,6 @@ from app.enricher import (
     EnricherStrategy,
     EnrichmentResult,
     ImplementationMetaData,
-    NodeUnsupportedException,
 )
 from app.enricher.utils import implementation, leqo_output
 from app.model.CompileRequest import (
@@ -48,7 +47,7 @@ class LiteralEnricherStrategy(EnricherStrategy):
     """
 
     @override
-    def _enrich_impl(
+    def _enrich_impl(  # noqa PLR0911 Too many return statements
         self, node: FrontendNode, constraints: Constraints | None
     ) -> EnrichmentResult | list[EnrichmentResult]:
         if constraints is not None and len(constraints.requested_inputs) != 0:
@@ -132,4 +131,4 @@ class LiteralEnricherStrategy(EnricherStrategy):
                     ),
                     ImplementationMetaData(width=0, depth=1),
                 )
-        raise NodeUnsupportedException(node)
+        return []


### PR DESCRIPTION
The `LiteralEnricherStrategy` still throws `NodeUnsupportedException` if a node is not supported.
As this is the expected case for most of the time, a strategy should return empty list instead.

This will result in clearer error messages and  theoretically improve performance.

# Definition of Done

- [x] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [x] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [x] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [x] **Deployment Readiness**: The work is ready for deployment to production if needed.
