### PR TITLE
fix: ruff update

### DIFF
--- a/app/openqasm3/rename.py
+++ b/app/openqasm3/rename.py
@@ -24,7 +24,7 @@ class _SimpleRenameTransformer(LeqoTransformer[None]):
 TNode = TypeVar("TNode", bound=QASMNode)
 
 
-def simple_rename(node: TNode, renamings: dict[str, str]) -> TNode:
+def simple_rename[TNode](node: TNode, renamings: dict[str, str]) -> TNode:
     """
     Renames variables in node according to the specified mapping.
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -27,7 +27,7 @@ def opt_call(func: Callable[[TParam], TReturn], arg: TParam | None) -> TReturn |
 T = TypeVar("T")
 
 
-def not_none(value: T | None, error_msg: str) -> T:
+def not_none[T](value: T | None, error_msg: str) -> T:
     """
     Returns value if not none or raises exception.
 
@@ -42,7 +42,7 @@ def not_none(value: T | None, error_msg: str) -> T:
     return value
 
 
-def not_none_or(value: T | None, default_value: T) -> T:
+def not_none_or[T](value: T | None, default_value: T) -> T:
     """
     Nullish coalescence - `??` operator.
     Returns `value` if not `None`.
@@ -55,7 +55,7 @@ def not_none_or(value: T | None, default_value: T) -> T:
     return value
 
 
-def duplicates(list: list[T]) -> set[T]:
+def duplicates[T](list: list[T]) -> set[T]:
     """
     Returns set of duplicate items.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ extend-select = [
     "UP", # pyupgrade
     "YTT", # flake8-2020
 ]
+ignore = ["UP047"] # ignore this warning so that we can use TypeVar("...", bound=...) and make mypy happy
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
Ruff was updated to 12.0 and raises now an error for code like this:

```py
TModel = TypeVar("TModel", bound=BaseModel)
def find_files(path: Path, model: type[TModel]) -> Iterator[TModel]:
    pass
```
it wants us to use
```py
TModel = TypeVar("TModel", bound=BaseModel)
def find_files[TypeVar](path: Path, model: type[TModel]) -> Iterator[TModel]:
    pass
```
but then mypy fails because it ignores the bound=...

it was solved by using new syntax where possible and tell ruff to ignore that warning

# Definition of Done

- [x] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [x] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [x] **Peer Review**: The code has undergone peer review by another team member.
- [x] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [x] **Deployment Readiness**: The work is ready for deployment to production if needed.
