### PR TITLE
docs: add field descriptions to openapi

### DIFF
--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.openqasm3.stdgates import (
     OneQubitGate,
@@ -23,13 +23,13 @@ from app.openqasm3.stdgates import (
 class OptimizeSettings(ABC):
     """
     Abstract base class providing optimization settings.
-
-    :param int | None optimizeWidth: If set, enables circuit width optimization with a user-defined priority.
-    :param int | None optimizeDepth: If set, enables circuit depth optimization with a user-defined priority.
     """
 
     optimizeWidth: int | None
+    """If set, enables circuit width optimization with a user-defined priority."""
+
     optimizeDepth: int | None
+    """If set, enables circuit depth optimization with a user-defined priority."""
 
 
 class MetaData(BaseModel, OptimizeSettings):
@@ -37,18 +37,25 @@ class MetaData(BaseModel, OptimizeSettings):
     Contains metadata for a compile request, including versioning and optimization preferences.
     """
 
-    version: str = Field(description="Version identifier of the project or model.")
-    name: str = Field(description="Name of the quantum circuit or model.")
-    description: str = Field(description="Human-readable description of the model.")
-    author: str = Field(description="Author of the model.")
-    optimizeWidth: Annotated[int, Field(gt=0)] | None = Field(
-        default=None,
-        description="Optimization setting for reducing circuit width (optional).",
-    )
-    optimizeDepth: Annotated[int, Field(gt=0)] | None = Field(
-        default=None,
-        description="Optimization setting for reducing circuit depth (optional).",
-    )
+    version: str
+    """Version identifier of the project or model."""
+
+    name: str
+    """Name of the quantum circuit or model."""
+
+    description: str
+    """Human-readable description of the model."""
+
+    author: str
+    """Author of the model."""
+
+    optimizeWidth: Annotated[int, Field(gt=0)] | None = None
+    """Optimization setting for reducing circuit width (optional)."""
+
+    optimizeDepth: Annotated[int, Field(gt=0)] | None = None
+    """Optimization setting for reducing circuit depth (optional)."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class BaseNode(BaseModel):
@@ -56,11 +63,13 @@ class BaseNode(BaseModel):
     Abstract base class for all node types used in a compile request.
     """
 
-    id: str = Field(description="Unique identifier for the node.")
-    label: str | None = Field(
-        default=None,
-        description="Optional label for the node used for display purposes.",
-    )
+    id: str
+    """Unique identifier for the node."""
+
+    label: str | None = None
+    """Optional label for the node used for display purposes."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class ImplementationNode(BaseNode):
@@ -69,9 +78,11 @@ class ImplementationNode(BaseNode):
     """
 
     type: Literal["implementation"] = "implementation"
-    implementation: str = Field(
-        description="Raw OpenQASM code associated with the node."
-    )
+
+    implementation: str
+    """Raw OpenQASM code associated with the node."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 # region Boundary Nodes
@@ -81,15 +92,14 @@ class EncodeValueNode(BaseNode):
     """
 
     type: Literal["encode"] = "encode"
-    encoding: Literal["amplitude", "angle", "basis", "custom", "matrix", "schmidt"] = (
-        Field(description='Encoding scheme used (e.g. "amplitude", "basis", etc.).')
-    )
-    bounds: int = Field(
-        ge=0,
-        default=0,
-        le=1,
-        description="Indicates whether values are clamped (0 or 1).",
-    )
+
+    encoding: Literal["amplitude", "angle", "basis", "custom", "matrix", "schmidt"]
+    """Encoding scheme used (e.g. "amplitude", "basis", etc.)."""
+
+    bounds: int = Field(ge=0, default=0, le=1)
+    """Indicates whether values are clamped (0 or 1)."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class PrepareStateNode(BaseNode):
@@ -98,12 +108,14 @@ class PrepareStateNode(BaseNode):
     """
 
     type: Literal["prepare"] = "prepare"
-    quantumState: Literal["ϕ+", "ϕ-", "ψ+", "ψ-", "custom", "ghz", "uniform", "w"] = (
-        Field(description='Type of quantum state to prepare (e.g. "ψ+", "ghz").')
-    )
-    size: int = Field(
-        gt=0, description="Number of qubits involved in state preparation."
-    )
+
+    quantumState: Literal["ϕ+", "ϕ-", "ψ+", "ψ-", "custom", "ghz", "uniform", "w"]
+    """Type of quantum state to prepare (e.g. "ψ+", "ghz")."""
+
+    size: int = Field(gt=0)
+    """Number of qubits involved in state preparation."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class SplitterNode(BaseNode):
@@ -112,7 +124,11 @@ class SplitterNode(BaseNode):
     """
 
     type: Literal["splitter"] = "splitter"
-    numberOutputs: int = Field(ge=2, description="Number of output branches created.")
+
+    numberOutputs: int = Field(ge=2)
+    """Number of output branches created."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class MergerNode(BaseNode):
@@ -121,7 +137,11 @@ class MergerNode(BaseNode):
     """
 
     type: Literal["merger"] = "merger"
-    numberInputs: int = Field(ge=2, description="Number of input branches merged.")
+
+    numberInputs: int = Field(ge=2)
+    """Number of input branches merged."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class MeasurementNode(BaseNode):
@@ -130,9 +150,11 @@ class MeasurementNode(BaseNode):
     """
 
     type: Literal["measure"] = "measure"
-    indices: list[Annotated[int, Field(ge=0)]] = Field(
-        description="List of qubit indices to measure."
-    )
+
+    indices: list[Annotated[int, Field(ge=0)]]
+    """List of qubit indices to measure."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 BoundaryNode = (
@@ -147,7 +169,11 @@ class QubitNode(BaseNode):
     """
 
     type: Literal["qubit"] = "qubit"
-    size: int = Field(default=1, ge=1, description="Number of qubits to allocate.")
+
+    size: int = Field(default=1, ge=1)
+    """Number of qubits to allocate."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class GateNode(BaseNode):
@@ -156,9 +182,11 @@ class GateNode(BaseNode):
     """
 
     type: Literal["gate"] = "gate"
-    gate: OneQubitGate | TwoQubitGate | ThreeQubitGate | Literal["cnot", "toffoli"] = (
-        Field(description='The gate to apply (e.g., "x", "cnot", etc.).')
-    )
+
+    gate: OneQubitGate | TwoQubitGate | ThreeQubitGate | Literal["cnot", "toffoli"]
+    """The gate to apply (e.g., "x", "cnot", etc.)."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class ParameterizedGateNode(BaseNode):
@@ -167,10 +195,14 @@ class ParameterizedGateNode(BaseNode):
     """
 
     type: Literal["gate-with-param"] = "gate-with-param"
-    gate: OneQubitGateWithAngle | TwoQubitGateWithParam | TwoQubitGateWithAngle = Field(
-        description="The parameterized gate to apply."
-    )
-    parameter: float = Field(description="Value of the gate's parameter.")
+
+    gate: OneQubitGateWithAngle | TwoQubitGateWithParam | TwoQubitGateWithAngle
+    """The parameterized gate to apply."""
+
+    parameter: float
+    """Value of the gate's parameter."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 # region Literals
@@ -180,7 +212,11 @@ class BitLiteralNode(BaseNode):
     """
 
     type: Literal["bit"] = "bit"
-    value: Literal[0, 1] = Field(description="Bit value.")
+
+    value: Literal[0, 1]
+    """Bit value."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class BoolLiteralNode(BaseNode):
@@ -189,7 +225,11 @@ class BoolLiteralNode(BaseNode):
     """
 
     type: Literal["bool"] = "bool"
-    value: bool = Field(description="Boolean value.")
+
+    value: bool
+    """Boolean value."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class IntLiteralNode(BaseNode):
@@ -198,10 +238,14 @@ class IntLiteralNode(BaseNode):
     """
 
     type: Literal["int"] = "int"
-    bitSize: int = Field(
-        default=32, ge=1, description="Bit size of the integer (optional)."
-    )
-    value: int = Field(description="Integer value.")
+
+    bitSize: int = Field(default=32, ge=1)
+    """"Bit size of the integer (optional)."""
+
+    value: int
+    """Integer value."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class FloatLiteralNode(BaseNode):
@@ -210,10 +254,14 @@ class FloatLiteralNode(BaseNode):
     """
 
     type: Literal["float"] = "float"
-    bitSize: int = Field(
-        default=32, ge=1, description="Bit size of the float (optional)."
-    )
-    value: float = Field(description="Float value.")
+
+    bitSize: int = Field(default=32, ge=1)
+    """Bit size of the float (optional)."""
+
+    value: float
+    """Float value."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 LiteralNode = BitLiteralNode | BoolLiteralNode | IntLiteralNode | FloatLiteralNode
@@ -226,9 +274,11 @@ class AncillaNode(BaseNode):
     """
 
     type: Literal["ancilla"] = "ancilla"
-    size: int = Field(
-        default=1, ge=1, description="Number of ancilla qubits allocated."
-    )
+
+    size: int = Field(default=1, ge=1)
+    """Number of ancilla qubits allocated."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 # region ControlFlow
@@ -237,8 +287,13 @@ class NestedBlock(BaseModel):
     Represents a subgraph or code block used inside control flow nodes.
     """
 
-    nodes: list[NestableNode] = Field(description="List of nodes within the block.")
-    edges: list[Edge] = Field(description="Connections between the nodes.")
+    nodes: list[NestableNode]
+    """List of nodes within the block."""
+
+    edges: list[Edge]
+    """Connections between the nodes."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class IfThenElseNode(BaseNode):
@@ -247,13 +302,17 @@ class IfThenElseNode(BaseNode):
     """
 
     type: Literal["if-then-else"] = "if-then-else"
-    condition: str = Field(description="Condition expression used to branch execution.")
-    thenBlock: NestedBlock = Field(
-        description="Code block executed if the condition is true."
-    )
-    elseBlock: NestedBlock = Field(
-        description="Code block executed if the condition is false."
-    )
+
+    condition: str
+    """Condition expression used to branch execution."""
+
+    thenBlock: NestedBlock
+    """Code block executed if the condition is true."""
+
+    elseBlock: NestedBlock
+    """Code block executed if the condition is false."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class RepeatNode(BaseNode):
@@ -262,8 +321,14 @@ class RepeatNode(BaseNode):
     """
 
     type: Literal["repeat"] = "repeat"
-    iterations: int = Field(gt=0, description="Number of loop iterations.")
-    block: NestedBlock = Field(description="Code block to repeat.")
+
+    iterations: int = Field(gt=0)
+    """Number of loop iterations."""
+
+    block: NestedBlock
+    """Code block to repeat."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 ControlFlowNode = IfThenElseNode | RepeatNode
@@ -294,7 +359,10 @@ class OperatorNode(BaseNode):
         "!=",
         "min",
         "max",
-    ] = Field(description='Type of operator (e.g., "+", "&", "==").')
+    ]
+    """Type of operator (e.g., "+", "&", "==")."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 NestableNode = (
@@ -317,17 +385,22 @@ class Edge(BaseModel):
     source: tuple[
         Annotated[str, Field(description="Source node Id")],
         Annotated[int, Field(ge=0, description="Output index of source node")],
-    ] = Field(description="Tuple of (node_id, output_index).")
+    ]
+    """Tuple of (node_id, output_index)."""
+
     target: tuple[
         Annotated[str, Field(description="Target node id")],
         Annotated[int, Field(ge=0, description="Input index of target node")],
-    ] = Field(description="Tuple of (node_id, input_index).")
-    size: int | None = Field(
-        default=None, description="Optional size override for the edge."
-    )
-    identifier: str | None = Field(
-        default=None, description="Optional name or alias of the connection."
-    )
+    ]
+    """Tuple of (node_id, input_index)."""
+
+    size: int | None = None
+    """Optional size override for the edge"""
+
+    identifier: str | None = None
+    """Optional name or alias of the connection."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class CompileRequest(BaseModel):
@@ -335,15 +408,16 @@ class CompileRequest(BaseModel):
     Top-level object representing a full graph-based quantum compile request.
     """
 
-    metadata: MetaData = Field(
-        description="General information and optimization preferences."
-    )
-    nodes: list[Annotated[Node, Field(discriminator="type")]] = Field(
-        description="List of all nodes forming the program graph."
-    )
-    edges: list[Edge] = Field(
-        description="Directed edges defining input-output relationships between nodes."
-    )
+    metadata: MetaData
+    """General information and optimization preferences."""
+
+    nodes: list[Annotated[Node, Field(discriminator="type")]]
+    """List of all nodes forming the program graph."""
+
+    edges: list[Edge]
+    """Directed edges defining input-output relationships between nodes."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 EnrichableNode = (

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -35,110 +35,104 @@ class OptimizeSettings(ABC):
 class MetaData(BaseModel, OptimizeSettings):
     """
     Contains metadata for a compile request, including versioning and optimization preferences.
-
-    :param str version: Version identifier of the project or model.
-    :param str name: Name of the quantum circuit or model.
-    :param str description: Human-readable description of the model.
-    :param str author: Author of the model.
-    :param int | None optimizeWidth: Optimization setting for reducing circuit width (optional).
-    :param int | None optimizeDepth: Optimization setting for reducing circuit depth (optional).
     """
 
-    version: str
-    name: str
-    description: str
-    author: str
-    optimizeWidth: Annotated[int, Field(gt=0)] | None = None
-    optimizeDepth: Annotated[int, Field(gt=0)] | None = None
+    version: str = Field(description="Version identifier of the project or model.")
+    name: str = Field(description="Name of the quantum circuit or model.")
+    description: str = Field(description="Human-readable description of the model.")
+    author: str = Field(description="Author of the model.")
+    optimizeWidth: Annotated[int, Field(gt=0)] | None = Field(
+        default=None,
+        description="Optimization setting for reducing circuit width (optional).",
+    )
+    optimizeDepth: Annotated[int, Field(gt=0)] | None = Field(
+        default=None,
+        description="Optimization setting for reducing circuit depth (optional).",
+    )
 
 
 class BaseNode(BaseModel):
     """
     Abstract base class for all node types used in a compile request.
-
-    :param str id: Unique identifier for the node.
-    :param str | None label: Optional label for the node used for display purposes.
     """
 
-    id: str
-    label: str | None = None
+    id: str = Field(description="Unique identifier for the node.")
+    label: str | None = Field(
+        default=None,
+        description="Optional label for the node used for display purposes.",
+    )
 
 
 class ImplementationNode(BaseNode):
     """
     Node containing a user-defined OpenQASM implementation.
-
-    :param Literal["implementation"] type: Constant value indicating this node type.
-    :param str implementation: Raw OpenQASM code associated with the node.
     """
 
     type: Literal["implementation"] = "implementation"
-    implementation: str
+    implementation: str = Field(
+        description="Raw OpenQASM code associated with the node."
+    )
 
 
 # region Boundary Nodes
 class EncodeValueNode(BaseNode):
     """
     Node representing quantum state encoding from classical values.
-
-    :param Literal["encode"] type: Constant value indicating this node type.
-    :param Literal encoding: Encoding scheme used (e.g. "amplitude", "basis", etc.).
-    :param int bounds: Indicates whether values are clamped (0 or 1).
     """
 
     type: Literal["encode"] = "encode"
-    encoding: Literal["amplitude", "angle", "basis", "custom", "matrix", "schmidt"]
-    bounds: int = Field(ge=0, default=0, le=1)
+    encoding: Literal["amplitude", "angle", "basis", "custom", "matrix", "schmidt"] = (
+        Field(description='Encoding scheme used (e.g. "amplitude", "basis", etc.).')
+    )
+    bounds: int = Field(
+        ge=0,
+        default=0,
+        le=1,
+        description="Indicates whether values are clamped (0 or 1).",
+    )
 
 
 class PrepareStateNode(BaseNode):
     """
     Node for preparing known quantum states like Bell or GHZ.
-
-    :param Literal["prepare"] type: Constant value indicating this node type.
-    :param Literal quantumState: Type of quantum state to prepare (e.g. "ψ+", "ghz").
-    :param int size: Number of qubits involved in state preparation.
     """
 
     type: Literal["prepare"] = "prepare"
-    quantumState: Literal["ϕ+", "ϕ-", "ψ+", "ψ-", "custom", "ghz", "uniform", "w"]
-    size: int = Field(gt=0)
+    quantumState: Literal["ϕ+", "ϕ-", "ψ+", "ψ-", "custom", "ghz", "uniform", "w"] = (
+        Field(description='Type of quantum state to prepare (e.g. "ψ+", "ghz").')
+    )
+    size: int = Field(
+        gt=0, description="Number of qubits involved in state preparation."
+    )
 
 
 class SplitterNode(BaseNode):
     """
     Node that splits qubits into multiple branches.
-
-    :param Literal["splitter"] type: Constant value indicating this node type.
-    :param int numberOutputs: Number of output branches created.
     """
 
     type: Literal["splitter"] = "splitter"
-    numberOutputs: int = Field(ge=2)
+    numberOutputs: int = Field(ge=2, description="Number of output branches created.")
 
 
 class MergerNode(BaseNode):
     """
     Node that merges multiple input branches into a single stream.
-
-    :param Literal["merger"] type: Constant value indicating this node type.
-    :param int numberInputs: Number of input branches merged.
     """
 
     type: Literal["merger"] = "merger"
-    numberInputs: int = Field(ge=2)
+    numberInputs: int = Field(ge=2, description="Number of input branches merged.")
 
 
 class MeasurementNode(BaseNode):
     """
     Node performing quantum measurement on specified qubit indices.
-
-    :param Literal["measure"] type: Constant value indicating this node type.
-    :param list[int] indices: List of qubit indices to measure.
     """
 
     type: Literal["measure"] = "measure"
-    indices: list[Annotated[int, Field(ge=0)]]
+    indices: list[Annotated[int, Field(ge=0)]] = Field(
+        description="List of qubit indices to measure."
+    )
 
 
 BoundaryNode = (
@@ -150,92 +144,76 @@ BoundaryNode = (
 class QubitNode(BaseNode):
     """
     Node representing qubit allocation.
-
-    :param Literal["qubit"] type: Constant value indicating this node type.
-    :param int size: Number of qubits to allocate.
     """
 
     type: Literal["qubit"] = "qubit"
-    size: int = Field(default=1, ge=1)
+    size: int = Field(default=1, ge=1, description="Number of qubits to allocate.")
 
 
 class GateNode(BaseNode):
     """
     Node representing application of a quantum gate.
-
-    :param Literal["gate"] type: Constant value indicating this node type.
-    :param gate: The gate to apply (e.g., "x", "cnot", etc.).
     """
 
     type: Literal["gate"] = "gate"
-    gate: OneQubitGate | TwoQubitGate | ThreeQubitGate | Literal["cnot", "toffoli"]
+    gate: OneQubitGate | TwoQubitGate | ThreeQubitGate | Literal["cnot", "toffoli"] = (
+        Field(description='The gate to apply (e.g., "x", "cnot", etc.).')
+    )
 
 
 class ParameterizedGateNode(BaseNode):
     """
     Node representing a gate that requires a parameter (e.g., angle rotation).
-
-    :param Literal["gate-with-param"] type: Constant value indicating this node type.
-    :param gate: The parameterized gate to apply.
-    :param float parameter: Value of the gate's parameter.
     """
 
     type: Literal["gate-with-param"] = "gate-with-param"
-    gate: OneQubitGateWithAngle | TwoQubitGateWithParam | TwoQubitGateWithAngle
-    parameter: float
+    gate: OneQubitGateWithAngle | TwoQubitGateWithParam | TwoQubitGateWithAngle = Field(
+        description="The parameterized gate to apply."
+    )
+    parameter: float = Field(description="Value of the gate's parameter.")
 
 
 # region Literals
 class BitLiteralNode(BaseNode):
     """
     Node representing a fixed classical bit value (0 or 1).
-
-    :param Literal["bit"] type: Constant value indicating this node type.
-    :param Literal[0, 1] value: Bit value.
     """
 
     type: Literal["bit"] = "bit"
-    value: Literal[0, 1]
+    value: Literal[0, 1] = Field(description="Bit value.")
 
 
 class BoolLiteralNode(BaseNode):
     """
     Node representing a boolean literal.
-
-    :param Literal["bool"] type: Constant value indicating this node type.
-    :param bool value: Boolean value.
     """
 
     type: Literal["bool"] = "bool"
-    value: bool
+    value: bool = Field(description="Boolean value.")
 
 
 class IntLiteralNode(BaseNode):
     """
     Node representing an integer literal.
-
-    :param Literal["int"] type: Constant value indicating this node type.
-    :param int bitSize: Bit size of the integer.
-    :param int value: Integer value.
     """
 
     type: Literal["int"] = "int"
-    bitSize: int = Field(default=32, ge=1)
-    value: int
+    bitSize: int = Field(
+        default=32, ge=1, description="Bit size of the integer (optional)."
+    )
+    value: int = Field(description="Integer value.")
 
 
 class FloatLiteralNode(BaseNode):
     """
     Node representing a floating-point literal.
-
-    :param Literal["float"] type: Constant value indicating this node type.
-    :param int bitSize: Bit size of the float.
-    :param float value: Float value.
     """
 
     type: Literal["float"] = "float"
-    bitSize: int = Field(default=32, ge=1)
-    value: float
+    bitSize: int = Field(
+        default=32, ge=1, description="Bit size of the float (optional)."
+    )
+    value: float = Field(description="Float value.")
 
 
 LiteralNode = BitLiteralNode | BoolLiteralNode | IntLiteralNode | FloatLiteralNode
@@ -245,56 +223,47 @@ LiteralNode = BitLiteralNode | BoolLiteralNode | IntLiteralNode | FloatLiteralNo
 class AncillaNode(BaseNode):
     """
     Node allocating ancillary qubits for temporary computation.
-
-    :param Literal["ancilla"] type: Constant value indicating this node type.
-    :param int size: Number of ancilla qubits allocated.
     """
 
     type: Literal["ancilla"] = "ancilla"
-    size: int = Field(default=1, ge=1)
+    size: int = Field(
+        default=1, ge=1, description="Number of ancilla qubits allocated."
+    )
 
 
 # region ControlFlow
 class NestedBlock(BaseModel):
     """
     Represents a subgraph or code block used inside control flow nodes.
-
-    :param list[NestableNode] nodes: List of nodes within the block.
-    :param list[Edge] edges: Connections between the nodes.
     """
 
-    nodes: list[NestableNode]
-    edges: list[Edge]
+    nodes: list[NestableNode] = Field(description="List of nodes within the block.")
+    edges: list[Edge] = Field(description="Connections between the nodes.")
 
 
 class IfThenElseNode(BaseNode):
     """
     Node representing conditional execution.
-
-    :param Literal["if-then-else"] type: Constant value indicating this node type.
-    :param str condition: Condition expression used to branch execution.
-    :param NestedBlock thenBlock: Code block executed if the condition is true.
-    :param NestedBlock elseBlock: Code block executed if the condition is false.
     """
 
     type: Literal["if-then-else"] = "if-then-else"
-    condition: str
-    thenBlock: NestedBlock
-    elseBlock: NestedBlock
+    condition: str = Field(description="Condition expression used to branch execution.")
+    thenBlock: NestedBlock = Field(
+        description="Code block executed if the condition is true."
+    )
+    elseBlock: NestedBlock = Field(
+        description="Code block executed if the condition is false."
+    )
 
 
 class RepeatNode(BaseNode):
     """
     Node representing a repeat loop structure.
-
-    :param Literal["repeat"] type: Constant value indicating this node type.
-    :param int iterations: Number of loop iterations.
-    :param NestedBlock block: Code block to repeat.
     """
 
     type: Literal["repeat"] = "repeat"
-    iterations: int = Field(gt=0)
-    block: NestedBlock
+    iterations: int = Field(gt=0, description="Number of loop iterations.")
+    block: NestedBlock = Field(description="Code block to repeat.")
 
 
 ControlFlowNode = IfThenElseNode | RepeatNode
@@ -304,9 +273,6 @@ ControlFlowNode = IfThenElseNode | RepeatNode
 class OperatorNode(BaseNode):
     """
     Node representing a classical operation (arithmetic, bitwise, comparison).
-
-    :param Literal["operator"] type: Constant value indicating this node type.
-    :param Literal operator: Type of operator (e.g., "+", "&", "==").
     """
 
     type: Literal["operator"] = "operator"
@@ -328,7 +294,7 @@ class OperatorNode(BaseNode):
         "!=",
         "min",
         "max",
-    ]
+    ] = Field(description='Type of operator (e.g., "+", "&", "==").')
 
 
 NestableNode = (
@@ -346,31 +312,38 @@ Node = NestableNode | QubitNode | ControlFlowNode
 class Edge(BaseModel):
     """
     Represents a connection between two ports of nodes.
-
-    :param tuple[str, int] source: Tuple of (node_id, output_index).
-    :param tuple[str, int] target: Tuple of (node_id, input_index).
-    :param int | None size: Optional size override for the edge.
-    :param str | None identifier: Optional name or alias of the connection.
     """
 
-    source: tuple[str, Annotated[int, Field(ge=0)]]
-    target: tuple[str, Annotated[int, Field(ge=0)]]
-    size: int | None = None
-    identifier: str | None = None
+    source: tuple[
+        Annotated[str, Field(description="Source node Id")],
+        Annotated[int, Field(ge=0, description="Output index of source node")],
+    ] = Field(description="Tuple of (node_id, output_index).")
+    target: tuple[
+        Annotated[str, Field(description="Target node id")],
+        Annotated[int, Field(ge=0, description="Input index of target node")],
+    ] = Field(description="Tuple of (node_id, input_index).")
+    size: int | None = Field(
+        default=None, description="Optional size override for the edge."
+    )
+    identifier: str | None = Field(
+        default=None, description="Optional name or alias of the connection."
+    )
 
 
 class CompileRequest(BaseModel):
     """
     Top-level object representing a full graph-based quantum compile request.
-
-    :param MetaData metadata: General information and optimization preferences.
-    :param list[Node] nodes: List of all nodes forming the program graph.
-    :param list[Edge] edges: Directed edges defining input-output relationships between nodes.
     """
 
-    metadata: MetaData
-    nodes: list[Annotated[Node, Field(discriminator="type")]]
-    edges: list[Edge]
+    metadata: MetaData = Field(
+        description="General information and optimization preferences."
+    )
+    nodes: list[Annotated[Node, Field(discriminator="type")]] = Field(
+        description="List of all nodes forming the program graph."
+    )
+    edges: list[Edge] = Field(
+        description="Directed edges defining input-output relationships between nodes."
+    )
 
 
 EnrichableNode = (

--- a/app/model/StatusResponse.py
+++ b/app/model/StatusResponse.py
@@ -8,7 +8,7 @@ from enum import StrEnum
 from typing import Literal, Self
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.model.exceptions import LeqoProblemDetails
 
@@ -19,8 +19,13 @@ class StatusType(StrEnum):
     """
 
     IN_PROGRESS = "in progress"
+    """The operation is still in progress"""
+
     FAILED = "failed"
+    """The operation failed"""
+
     COMPLETED = "completed"
+    """The operation completed successfully"""
 
 
 class Progress(BaseModel):
@@ -28,10 +33,13 @@ class Progress(BaseModel):
     Models the progress of a compile request.
     """
 
-    percentage: int = Field(
-        ge=0, le=100, description="Progress percentage between 0 and 100."
-    )
-    currentStep: str = Field(description="Step that is currently executing.")
+    percentage: int = Field(ge=0, le=100)
+    """Progress percentage between 0 and 100."""
+
+    currentStep: str
+    """Step that is currently executing."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class StatusBase(BaseModel):
@@ -39,15 +47,32 @@ class StatusBase(BaseModel):
     Models the status of a process.
     """
 
-    uuid: UUID = Field(description="Id of the operation represented by this status.")
-    createdAt: datetime = Field(description="When this operation started.")
-    progress: Progress = Field(description="Progress of this operation.")
+    uuid: UUID
+    """Id of the operation represented by this status."""
+
+    createdAt: datetime
+    """When this operation started."""
+
+    progress: Progress
+    """Progress of this operation."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class CreatedStatus(StatusBase):
+    """
+    Models the status of a running operation.
+    """
+
     status: Literal[StatusType.IN_PROGRESS] = StatusType.IN_PROGRESS
+
     completedAt: None = None
+    """This operation is not completed yet."""
+
     result: None = None
+    """The operation does not have a result yet."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
     @classmethod
     def init_status(cls, uuid: UUID) -> Self:
@@ -59,19 +84,35 @@ class CreatedStatus(StatusBase):
 
 
 class SuccessStatus(StatusBase):
+    """
+    Models the status of a completed operation.
+    """
+
     status: Literal[StatusType.COMPLETED] = StatusType.COMPLETED
-    completedAt: datetime = Field(
-        description="When this operation completed successfully."
-    )
-    result: str = Field(description="Location of the result of this operation.")
+
+    completedAt: datetime
+    """When this operation completed successfully."""
+
+    result: str
+    """Location of the result of this operation."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 class FailedStatus(StatusBase):
+    """
+    Models the status of a failed operation.
+    """
+
     status: Literal[StatusType.FAILED] = StatusType.FAILED
+
     completedAt: None = None
-    result: LeqoProblemDetails = Field(
-        description="Machine-readable error information."
-    )
+    """The operation did not complete (successfully)."""
+
+    result: LeqoProblemDetails
+    """Machine-readable error information."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
 
 
 StatusResponse = CreatedStatus | SuccessStatus | FailedStatus

--- a/app/model/StatusResponse.py
+++ b/app/model/StatusResponse.py
@@ -8,7 +8,7 @@ from enum import StrEnum
 from typing import Literal, Self
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.model.exceptions import LeqoProblemDetails
 
@@ -28,8 +28,10 @@ class Progress(BaseModel):
     Models the progress of a compile request.
     """
 
-    percentage: int
-    currentStep: str
+    percentage: int = Field(
+        ge=0, le=100, description="Progress percentage between 0 and 100."
+    )
+    currentStep: str = Field(description="Step that is currently executing.")
 
 
 class StatusBase(BaseModel):
@@ -37,9 +39,9 @@ class StatusBase(BaseModel):
     Models the status of a process.
     """
 
-    uuid: UUID
-    createdAt: datetime
-    progress: Progress
+    uuid: UUID = Field(description="Id of the operation represented by this status.")
+    createdAt: datetime = Field(description="When this operation started.")
+    progress: Progress = Field(description="Progress of this operation.")
 
 
 class CreatedStatus(StatusBase):
@@ -58,14 +60,18 @@ class CreatedStatus(StatusBase):
 
 class SuccessStatus(StatusBase):
     status: Literal[StatusType.COMPLETED] = StatusType.COMPLETED
-    completedAt: datetime
-    result: str
+    completedAt: datetime = Field(
+        description="When this operation completed successfully."
+    )
+    result: str = Field(description="Location of the result of this operation.")
 
 
 class FailedStatus(StatusBase):
     status: Literal[StatusType.FAILED] = StatusType.FAILED
     completedAt: None = None
-    result: LeqoProblemDetails
+    result: LeqoProblemDetails = Field(
+        description="Machine-readable error information."
+    )
 
 
 StatusResponse = CreatedStatus | SuccessStatus | FailedStatus


### PR DESCRIPTION
The docs were previously added via sphinx syntax in docstrings but the openapi-schema-generation of fastapi cannot extract those. Therfore we're now using docstrings for the individual fields with the [`use_attribute_docstrings`](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.use_attribute_docstrings) pydantic setting.
```python
model_config = ConfigDict(use_attribute_docstrings=True)
```

# Definition of Done

- [x] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [x] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [x] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [x] **Deployment Readiness**: The work is ready for deployment to production if needed.
