### PR TITLE
basis-encoding fix for float array

### DIFF
--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -321,7 +321,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         elif isinstance(classical_input, ast.ArrayType):
             res = self._get_array_length(classical_input)
         elif isinstance(classical_input, ast.FloatType):
-            res = 1
+            res = int(classical_input.size.value if hasattr(classical_input, "size") and classical_input.size else 32)
         else:
             size = 0
             match classical_input:
@@ -334,7 +334,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                 case data_types.BitType():
                     size = classical_input.size or 1
                 case data_types.FloatType():
-                    size = 1
+                    size = classical_input.size if hasattr(classical_input, "size") and classical_input.size else 32
                 case _:
                     if hasattr(classical_input, "size") and isinstance(
                         classical_input.size, int
@@ -348,6 +348,16 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                 raise InputSizeMismatch(node, 0, actual=size, expected=1)
             res = size
         return res
+    
+    def _float_to_fixed_point_indices(self, value: float, element_size: int) -> list[int]:
+        """
+        Approximates a floating point number into a fixed-point binary representation
+        and returns the indices of the '1' bits. Dynamically scales fractional precision.
+        """
+        fractional_bits = element_size // 2
+        scaled_value = int(round(value * (1 << fractional_bits)))
+        mask = scaled_value & ((1 << element_size) - 1)
+        return [index for index in range(element_size) if (mask >> index) & 1]
 
     def _constant_basis_indices(
         self,
@@ -356,14 +366,34 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         raw_value: Any,
     ) -> list[int]:
         if isinstance(classical_input, data_types.FloatType):
-            raise RuntimeError("FloatType not supported for basis encoding")
+            try:
+                v = float(raw_value.value if hasattr(raw_value, "value") else raw_value)
+                return self._float_to_fixed_point_indices(v, register_size)
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError("Unsupported float input for basis encoding") from exc
 
         if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
             values = self._coerce_array_constant_value(classical_input, raw_value)
             element_type = self._get_element_type(classical_input)
 
             if isinstance(element_type, (data_types.FloatType, ast.FloatType)):
-                raise RuntimeError("Float Array not supported for basis encoding")
+                if hasattr(element_type, "size") and element_type.size:
+                    element_size = int(element_type.size.value if hasattr(element_type.size, "value") else element_type.size)
+                else:
+                    element_size = 32
+                mask_limit = (1 << element_size) - 1
+                fractional_bits = element_size // 2
+                indices: list[int] = []
+                for element_index, element_value in enumerate(values):
+                    scaled_val = int(round(float(element_value) * (1 << fractional_bits)))
+                    mask = scaled_val & mask_limit
+                    base_offset = element_index * element_size
+                    indices.extend(
+                        base_offset + bit
+                        for bit in range(element_size)
+                        if (mask >> bit) & 1
+                    )
+                return indices
 
             if hasattr(element_type, "size"):
                 element_size = element_type.size
@@ -833,9 +863,13 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                 collection=value_identifier,
                 index=[ast.IntegerLiteral(element_index)],
             )
+            is_float = isinstance(element_type, (data_types.FloatType, ast.FloatType))
+            shift_target = element_expr
+            if is_float:
+                shift_target = ast.Cast(ast.IntegerType(), element_expr)
             shifted = ast.BinaryExpression(
                 ast.BinaryOperator[">>"],
-                element_expr,
+                shift_target,
                 ast.IntegerLiteral(bit_index),
             )
             masked = ast.BinaryExpression(
@@ -881,6 +915,21 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                     ast.IntegerLiteral(1),
                 )
             case data_types.FloatType():
-                raise RuntimeError("FloatType not supported for basis encoding")
+                int_cast = ast.Cast(ast.IntegerType(), value_identifier)
+                shifted = ast.BinaryExpression(
+                    ast.BinaryOperator[">>"],
+                    int_cast,
+                    ast.IntegerLiteral(index),
+                )
+                masked = ast.BinaryExpression(
+                    ast.BinaryOperator["&"],
+                    shifted,
+                    ast.IntegerLiteral(1),
+                )
+                return ast.BinaryExpression(
+                    ast.BinaryOperator["=="],
+                    masked,
+                    ast.IntegerLiteral(1),
+                )
             case _:
                 raise RuntimeError("Unsupported classical input for basis encoding")

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -321,7 +321,10 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         elif isinstance(classical_input, ast.ArrayType):
             res = self._get_array_length(classical_input)
         elif isinstance(classical_input, ast.FloatType):
-            res = int(classical_input.size.value if hasattr(classical_input, "size") and classical_input.size else 32)
+            res = int(
+                classical_input.size.value
+                if hasattr(classical_input, "size") and classical_input.size
+                else 32)
         else:
             size = 0
             match classical_input:
@@ -334,7 +337,11 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                 case data_types.BitType():
                     size = classical_input.size or 1
                 case data_types.FloatType():
-                    size = classical_input.size if hasattr(classical_input, "size") and classical_input.size else 32
+                    size = (
+                        classical_input.size
+                        if hasattr(classical_input, "size") and classical_input.size
+                        else 32
+                    )
                 case _:
                     if hasattr(classical_input, "size") and isinstance(
                         classical_input.size, int
@@ -356,6 +363,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         """
         fractional_bits = element_size // 2
         scaled_value = int(round(value * (1 << fractional_bits)))
+
         mask = scaled_value & ((1 << element_size) - 1)
         return [index for index in range(element_size) if (mask >> index) & 1]
 
@@ -367,10 +375,16 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
     ) -> list[int]:
         if isinstance(classical_input, data_types.FloatType):
             try:
-                v = float(raw_value.value if hasattr(raw_value, "value") else raw_value)
+                v = float(
+                    raw_value.value
+                    if hasattr(raw_value, "value")
+                    else raw_value
+                )
                 return self._float_to_fixed_point_indices(v, register_size)
             except (TypeError, ValueError) as exc:
-                raise RuntimeError("Unsupported float input for basis encoding") from exc
+                raise RuntimeError(
+                    "Unsupported float input for basis encoding"
+                ) from exc
 
         if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
             values = self._coerce_array_constant_value(classical_input, raw_value)
@@ -378,14 +392,21 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
 
             if isinstance(element_type, (data_types.FloatType, ast.FloatType)):
                 if hasattr(element_type, "size") and element_type.size:
-                    element_size = int(element_type.size.value if hasattr(element_type.size, "value") else element_type.size)
+                    element_size = int(
+                        element_type.size.value
+                        if hasattr(element_type.size, "value")
+                        else element_type.size
+                    )
                 else:
                     element_size = 32
+
                 mask_limit = (1 << element_size) - 1
                 fractional_bits = element_size // 2
                 indices: list[int] = []
                 for element_index, element_value in enumerate(values):
-                    scaled_val = int(round(float(element_value) * (1 << fractional_bits)))
+                    scaled_val = int(
+                        round(float(element_value) * (1 << fractional_bits))
+                    )
                     mask = scaled_val & mask_limit
                     base_offset = element_index * element_size
                     indices.extend(

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -365,7 +365,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         and returns the indices of the '1' bits. Dynamically scales fractional precision.
         """
         fractional_bits = element_size // 2
-        scaled_value = int(round(value * (1 << fractional_bits)))
+        scaled_value = round(value * (1 << fractional_bits))
         mask = scaled_value & ((1 << element_size) - 1)
         return [index for index in range(element_size) if (mask >> index) & 1]
 
@@ -392,7 +392,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             fractional_bits = element_size // 2
             indices: list[int] = []
             for element_index, element_value in enumerate(values):
-                scaled_val = int(round(float(element_value) * (1 << fractional_bits)))
+                scaled_val = round(float(element_value) * (1 << fractional_bits))
                 mask = scaled_val & mask_limit
                 base_offset = element_index * element_size
                 indices.extend(
@@ -404,9 +404,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
 
         if hasattr(element_type, "size"):
             element_size = element_type.size
-        elif isinstance(element_type, ast.ArrayType) or hasattr(
-            element_type, "value"
-        ):
+        elif isinstance(element_type, ast.ArrayType) or hasattr(element_type, "value"):
             element_size = element_type.value
         else:
             element_size = 32
@@ -421,9 +419,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             mask = int(element_value) & mask_limit
             base_offset = element_index * element_size
             indices.extend(
-                base_offset + bit
-                for bit in range(element_size)
-                if (mask >> bit) & 1
+                base_offset + bit for bit in range(element_size) if (mask >> bit) & 1
             )
         return indices
 

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -356,7 +356,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                 raise InputSizeMismatch(node, 0, actual=size, expected=1)
             res = size
         return res
-    
+
     def _float_to_fixed_point_indices(
         self, value: float, element_size: int
     ) -> list[int]:

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -324,7 +324,8 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             res = int(
                 classical_input.size.value
                 if hasattr(classical_input, "size") and classical_input.size
-                else 32)
+                else 32
+            )
         else:
             size = 0
             match classical_input:
@@ -356,14 +357,15 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             res = size
         return res
     
-    def _float_to_fixed_point_indices(self, value: float, element_size: int) -> list[int]:
+    def _float_to_fixed_point_indices(
+        self, value: float, element_size: int
+    ) -> list[int]:
         """
         Approximates a floating point number into a fixed-point binary representation
         and returns the indices of the '1' bits. Dynamically scales fractional precision.
         """
         fractional_bits = element_size // 2
         scaled_value = int(round(value * (1 << fractional_bits)))
-
         mask = scaled_value & ((1 << element_size) - 1)
         return [index for index in range(element_size) if (mask >> index) & 1]
 

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -369,6 +369,64 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         mask = scaled_value & ((1 << element_size) - 1)
         return [index for index in range(element_size) if (mask >> index) & 1]
 
+    def _array_basis_indices(
+        self,
+        classical_input: data_types.LeqoSupportedClassicalType,
+        raw_value: Any,
+    ) -> list[int]:
+        """Helper method to handle array logic, reducing branch complexity."""
+        values = self._coerce_array_constant_value(classical_input, raw_value)
+        element_type = self._get_element_type(classical_input)
+
+        if isinstance(element_type, (data_types.FloatType, ast.FloatType)):
+            if hasattr(element_type, "size") and element_type.size:
+                element_size = int(
+                    element_type.size.value
+                    if hasattr(element_type.size, "value")
+                    else element_type.size
+                )
+            else:
+                element_size = 32
+
+            mask_limit = (1 << element_size) - 1
+            fractional_bits = element_size // 2
+            indices: list[int] = []
+            for element_index, element_value in enumerate(values):
+                scaled_val = int(round(float(element_value) * (1 << fractional_bits)))
+                mask = scaled_val & mask_limit
+                base_offset = element_index * element_size
+                indices.extend(
+                    base_offset + bit
+                    for bit in range(element_size)
+                    if (mask >> bit) & 1
+                )
+            return indices
+
+        if hasattr(element_type, "size"):
+            element_size = element_type.size
+        elif isinstance(element_type, ast.ArrayType) or hasattr(
+            element_type, "value"
+        ):
+            element_size = element_type.value
+        else:
+            element_size = 32
+
+        if hasattr(element_size, "value"):
+            element_size = element_size.value
+        element_size = int(element_size)
+
+        mask_limit = (1 << element_size) - 1
+        indices = []
+        for element_index, element_value in enumerate(values):
+            mask = int(element_value) & mask_limit
+            base_offset = element_index * element_size
+            indices.extend(
+                base_offset + bit
+                for bit in range(element_size)
+                if (mask >> bit) & 1
+            )
+        return indices
+
     def _constant_basis_indices(
         self,
         classical_input: data_types.LeqoSupportedClassicalType,
@@ -377,11 +435,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
     ) -> list[int]:
         if isinstance(classical_input, data_types.FloatType):
             try:
-                v = float(
-                    raw_value.value
-                    if hasattr(raw_value, "value")
-                    else raw_value
-                )
+                v = float(raw_value.value if hasattr(raw_value, "value") else raw_value)
                 return self._float_to_fixed_point_indices(v, register_size)
             except (TypeError, ValueError) as exc:
                 raise RuntimeError(
@@ -389,59 +443,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                 ) from exc
 
         if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
-            values = self._coerce_array_constant_value(classical_input, raw_value)
-            element_type = self._get_element_type(classical_input)
-
-            if isinstance(element_type, (data_types.FloatType, ast.FloatType)):
-                if hasattr(element_type, "size") and element_type.size:
-                    element_size = int(
-                        element_type.size.value
-                        if hasattr(element_type.size, "value")
-                        else element_type.size
-                    )
-                else:
-                    element_size = 32
-
-                mask_limit = (1 << element_size) - 1
-                fractional_bits = element_size // 2
-                indices: list[int] = []
-                for element_index, element_value in enumerate(values):
-                    scaled_val = int(
-                        round(float(element_value) * (1 << fractional_bits))
-                    )
-                    mask = scaled_val & mask_limit
-                    base_offset = element_index * element_size
-                    indices.extend(
-                        base_offset + bit
-                        for bit in range(element_size)
-                        if (mask >> bit) & 1
-                    )
-                return indices
-
-            if hasattr(element_type, "size"):
-                element_size = element_type.size
-            elif isinstance(element_type, ast.ArrayType) or hasattr(
-                element_type, "value"
-            ):
-                element_size = element_type.value
-            else:
-                element_size = 32
-
-            if hasattr(element_size, "value"):
-                element_size = element_size.value
-            element_size = int(element_size)
-
-            mask_limit = (1 << element_size) - 1
-            indices: list[int] = []
-            for element_index, element_value in enumerate(values):
-                mask = int(element_value) & mask_limit
-                base_offset = element_index * element_size
-                indices.extend(
-                    base_offset + bit
-                    for bit in range(element_size)
-                    if (mask >> bit) & 1
-                )
-            return indices
+            return self._array_basis_indices(classical_input, raw_value)
 
         try:
             value = int(raw_value)

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -341,15 +341,24 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         fractional_bits = 0
         element_type = self._get_element_type(classical_input) if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)) else classical_input
         is_float_type = isinstance(element_type, (data_types.FloatType, ast.FloatType))
-        
+
         if not is_float_type and input_value is not None:
             try:
                 if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
                     vals = self._coerce_array_constant_value(classical_input, input_value)
-                    is_float_type = any(isinstance(v, float) or (isinstance(v, str) and "." in str(v)) for v in vals)
+                    is_float_type = any(
+                        isinstance(v, float) or (isinstance(v, str) and "." in str(v))
+                        for v in vals
+                    )
                 else:
-                    v = input_value.value if hasattr(input_value, "value") else input_value
-                    is_float_type = isinstance(v, float) or (isinstance(v, str) and "." in str(v))
+                    v = (
+                        input_value.value
+                        if hasattr(input_value, "value")
+                        else input_value
+                    )
+                    is_float_type = isinstance(v, float) or (
+                        isinstance(v, str) and "." in str(v)
+                    )
             except Exception:
                 pass
 
@@ -642,7 +651,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                 return int(raw_value) < 0
             except (TypeError, ValueError):
                 return False
-            
+
         if isinstance(classical_input, (data_types.FloatType, ast.FloatType)):
             try:
                 return float(raw_value) < 0

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -5,7 +5,7 @@ Provides enricher strategy for enriching :class:`~app.model.CompileRequest.Encod
 import math
 from collections.abc import Iterable
 from dataclasses import dataclass
-from math import pi, sqrt
+from math import ceil, log2, pi, sqrt
 from typing import Any, cast, override
 
 from openqasm3 import ast
@@ -41,6 +41,12 @@ class _AngleEmissionContext:
     register_size: int
     rotation_map: dict[int, float] | None
     value_identifier: ast.Identifier | None
+
+
+@dataclass
+class BasisMetadata:
+    vector_length: int
+    fractional_bits: int
 
 
 class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
@@ -332,20 +338,24 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             classical_input, input_value
         )
 
-        # 1. Vector length for metadata
         vector_length = 1
         if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
             vector_length = self._get_array_length(classical_input)
 
-        # 2. Precision for metadata
         fractional_bits = 0
-        element_type = self._get_element_type(classical_input) if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)) else classical_input
+        element_type = (
+            self._get_element_type(classical_input)
+            if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType))
+            else classical_input
+        )
         is_float_type = isinstance(element_type, (data_types.FloatType, ast.FloatType))
 
         if not is_float_type and input_value is not None:
             try:
                 if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
-                    vals = self._coerce_array_constant_value(classical_input, input_value)
+                    vals = self._coerce_array_constant_value(
+                        classical_input, input_value
+                    )
                     is_float_type = any(
                         isinstance(v, float) or (isinstance(v, str) and "." in str(v))
                         for v in vals
@@ -366,12 +376,15 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             decimal_precision = getattr(node, "decimalPrecision", None)
             error_tolerance = getattr(node, "errorTolerance", 0.001)
             if decimal_precision is not None:
-                fractional_bits = math.ceil(decimal_precision * math.log2(10))
+                fractional_bits = ceil(decimal_precision * log2(10))
             else:
-                fractional_bits = math.ceil(-math.log2(error_tolerance)) if error_tolerance < 1 else 0
+                fractional_bits = (
+                    ceil(-log2(error_tolerance)) if error_tolerance < 1 else 0
+                )
 
+        metadata = BasisMetadata(vector_length, fractional_bits)
         statements = self._build_basis_statements(
-            classical_input, size, constant_indices, signed_output, vector_length, fractional_bits
+            classical_input, size, constant_indices, signed_output, metadata
         )
         depth = size if constant_indices is None else len(constant_indices)
         return EnrichmentResult(
@@ -430,10 +443,10 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         int_bits = max(1, max_mag.bit_length() + 1)
 
         if decimal_precision is not None:
-            frac_bits = math.ceil(decimal_precision * math.log2(10))
+            frac_bits = ceil(decimal_precision * log2(10))
         else:
             frac_bits = (
-                math.ceil(-math.log2(error_tolerance)) if error_tolerance < 1 else 0
+                ceil(-log2(error_tolerance)) if error_tolerance < 1 else 0
             )
 
         total_bits_per_num = int_bits + frac_bits
@@ -740,8 +753,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         _register_size: int,
         raw_value: Any,
     ) -> dict[int, float]:
-        """Calculates rotations while satisfying PLR0911."""
-        final_rotations: dict[int, float]
+        final_rotations: dict[int, float] = {0: 0.0}
 
         if isinstance(classical_input, (data_types.FloatType, ast.FloatType)):
             try:
@@ -775,8 +787,6 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         elif isinstance(classical_input, (data_types.BitType, data_types.BoolType)):
             v = int(raw_value.value if hasattr(raw_value, "value") else raw_value)
             final_rotations = {0: v * (pi / 2)}
-        else:
-            final_rotations = {0: 0.0}
 
         return final_rotations
 
@@ -786,8 +796,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         register_size: int,
         constant_indices: list[int] | None,
         signed_output: bool,
-        vector_length: int = 1,
-        fractional_bits: int = 0,
+        meta: BasisMetadata,
     ) -> list[ast.Statement]:
         qubit_identifier = ast.Identifier("encoded")
         statements: list[ast.Statement] = [ast.Include("stdgates.inc")]
@@ -846,13 +855,13 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             output_alias.annotations.append(
                 ast.Annotation("leqo.twos_complement", "true")
             )
-            
+
         output_alias.annotations.append(
-            ast.Annotation("leqo.length", str(vector_length))
+            ast.Annotation("leqo.length", str(meta.vector_length))
         )
-        if fractional_bits > 0:
+        if meta.fractional_bits > 0:
             output_alias.annotations.append(
-                ast.Annotation("leqo.fractional_bits", str(fractional_bits))
+                ast.Annotation("leqo.fractional_bits", str(meta.fractional_bits))
             )
 
         statements.append(output_alias)

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -24,7 +24,6 @@ from app.enricher.utils import implementation, leqo_output
 from app.model import CompileRequest, data_types
 from app.model.exceptions import (
     InputCountMismatch,
-    InputSizeMismatch,
     InputTypeMismatch,
 )
 
@@ -360,19 +359,18 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         array_len = self._get_array_length(classical_input)
         element_type = self._get_element_type(classical_input)
 
-        if isinstance(element_type, (data_types.FloatType, ast.FloatType)):
-            if input_value is not None:
-                try:
-                    values = self._coerce_array_constant_value(
-                        classical_input, input_value
-                    )
-                    _, _, bits_per_element = self._calculate_fixed_point_params(
-                        values,
-                        getattr(node, "decimalPrecision", None),
-                        getattr(node, "errorTolerance", 0.001),
-                    )
-                    return array_len * bits_per_element
-                except Exception:
+        if isinstance(element_type, (data_types.FloatType, ast.FloatType)) and input_value is not None:
+            try:
+                values = self._coerce_array_constant_value(
+                    classical_input, input_value
+                )
+                _, _, bits_per_element = self._calculate_fixed_point_params(
+                    values,
+                    getattr(node, "decimalPrecision", None),
+                    getattr(node, "errorTolerance", 0.001),
+                )
+                return array_len * bits_per_element
+            except Exception:
                     pass
 
         if isinstance(classical_input, data_types.ArrayType):

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -2,7 +2,6 @@
 Provides enricher strategy for enriching :class:`~app.model.CompileRequest.EncodeValueNode` from a database.
 """
 
-import math
 from collections.abc import Iterable
 from dataclasses import dataclass
 from math import ceil, log2, pi, sqrt

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -263,8 +263,38 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         signed_output = self._basis_output_requires_signed_flag(
             classical_input, input_value
         )
+
+        # 1. Vector length for metadata
+        vector_length = 1
+        if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
+            vector_length = self._get_array_length(classical_input)
+
+        # 2. Precision for metadata
+        fractional_bits = 0
+        element_type = self._get_element_type(classical_input) if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)) else classical_input
+        is_float_type = isinstance(element_type, (data_types.FloatType, ast.FloatType))
+        
+        if not is_float_type and input_value is not None:
+            try:
+                if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
+                    vals = self._coerce_array_constant_value(classical_input, input_value)
+                    is_float_type = any(isinstance(v, float) or (isinstance(v, str) and "." in str(v)) for v in vals)
+                else:
+                    v = input_value.value if hasattr(input_value, "value") else input_value
+                    is_float_type = isinstance(v, float) or (isinstance(v, str) and "." in str(v))
+            except Exception:
+                pass
+
+        if is_float_type:
+            decimal_precision = getattr(node, "decimalPrecision", None)
+            error_tolerance = getattr(node, "errorTolerance", 0.001)
+            if decimal_precision is not None:
+                fractional_bits = math.ceil(decimal_precision * math.log2(10))
+            else:
+                fractional_bits = math.ceil(-math.log2(error_tolerance)) if error_tolerance < 1 else 0
+
         statements = self._build_basis_statements(
-            classical_input, size, constant_indices, signed_output
+            classical_input, size, constant_indices, signed_output, vector_length, fractional_bits
         )
         depth = size if constant_indices is None else len(constant_indices)
         return EnrichmentResult(
@@ -691,6 +721,8 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         register_size: int,
         constant_indices: list[int] | None,
         signed_output: bool,
+        vector_length: int = 1,
+        fractional_bits: int = 0,
     ) -> list[ast.Statement]:
         qubit_identifier = ast.Identifier("encoded")
         statements: list[ast.Statement] = [ast.Include("stdgates.inc")]
@@ -749,6 +781,15 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             output_alias.annotations.append(
                 ast.Annotation("leqo.twos_complement", "true")
             )
+            
+        output_alias.annotations.append(
+            ast.Annotation("leqo.length", str(vector_length))
+        )
+        if fractional_bits > 0:
+            output_alias.annotations.append(
+                ast.Annotation("leqo.fractional_bits", str(fractional_bits))
+            )
+
         statements.append(output_alias)
         return statements
 

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -2,6 +2,7 @@
 Provides enricher strategy for enriching :class:`~app.model.CompileRequest.EncodeValueNode` from a database.
 """
 
+import math
 from collections.abc import Iterable
 from dataclasses import dataclass
 from math import pi
@@ -250,12 +251,12 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         classical_input: data_types.LeqoSupportedClassicalType,
         input_value: Any | None,
     ) -> EnrichmentResult:
-        size = self._determine_register_size(node, classical_input)
+        size = self._determine_register_size(node, classical_input, input_value)
         constant_indices: list[int] | None = None
         if input_value is not None:
             try:
                 constant_indices = self._constant_basis_indices(
-                    classical_input, size, input_value
+                    node, classical_input, size, input_value
                 )
             except RuntimeError:
                 constant_indices = None
@@ -281,7 +282,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
             register_size = self._get_array_length(classical_input)
         else:
-            register_size = self._determine_register_size(node, classical_input)
+            register_size = self._determine_register_size(node, classical_input, input_value)
 
         rotation_map: dict[int, float] | None = None
         if input_value is not None:
@@ -306,43 +307,123 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             implementation(node, statements),
             ImplementationMetaData(width=register_size, depth=depth),
         )
+    
+    def _calculate_fixed_point_params(
+        self, values: list[float], decimal_precision: int | None, error_tolerance: float
+    ) -> tuple[int, int, int]:
+        """
+        Dynamically calculates the minimal required qubits for fixed point encoding.
+        Returns: (integer_bits, fractional_bits, total_bits_per_element)
+        """
+        if not values:
+            return 1, 0, 1
+
+        max_mag = max(abs(int(v)) for v in values)
+        int_bits = max(1, max_mag.bit_length() + 1) 
+
+        if decimal_precision is not None:
+            frac_bits = math.ceil(decimal_precision * math.log2(10))
+        else:
+            frac_bits = math.ceil(-math.log2(error_tolerance)) if error_tolerance < 1 else 0
+
+        total_bits_per_num = int_bits + frac_bits
+        return int_bits, frac_bits, total_bits_per_num
 
     def _determine_register_size(
         self,
         node: CompileRequest.EncodeValueNode,
         classical_input: data_types.LeqoSupportedClassicalType,
+        input_value: Any | None = None,
     ) -> int:
-        """Determines size while satisfying PLR0911."""
         res: int
         if node.encoding == "angle" and not isinstance(
             classical_input, (data_types.ArrayType, ast.ArrayType)
         ):
             res = 1
         elif isinstance(classical_input, ast.ArrayType):
-            res = self._get_array_length(classical_input)
+            array_len = self._get_array_length(classical_input)
+            element_type = self._get_element_type(classical_input)
+            if isinstance(element_type, ast.FloatType) and input_value is not None:
+                try:
+                    values = self._coerce_array_constant_value(classical_input, input_value)
+                    _, _, bits_per_element = self._calculate_fixed_point_params(
+                        values, 
+                        getattr(node, 'decimalPrecision', None), 
+                        getattr(node, 'errorTolerance', 0.001)
+                    )
+                    res = array_len * bits_per_element
+                except Exception:
+                    res = array_len * 32
+            else:
+                if hasattr(element_type, "size") and element_type.size:
+                    size_val = element_type.size.value if hasattr(element_type.size, "value") else element_type.size
+                    res = array_len * int(size_val)
+                elif isinstance(element_type, ast.ArrayType) or hasattr(element_type, "value"):
+                    res = array_len * int(element_type.value)
+                else:
+                    res = array_len * 32
+        elif isinstance(classical_input, data_types.ArrayType):
+            element_type = self._get_element_type(classical_input)
+            if isinstance(element_type, data_types.FloatType) and input_value is not None:
+                try:
+                    array_len = self._get_array_length(classical_input)
+                    values = self._coerce_array_constant_value(classical_input, input_value)
+                    _, _, bits_per_element = self._calculate_fixed_point_params(
+                        values, 
+                        getattr(node, 'decimalPrecision', None), 
+                        getattr(node, 'errorTolerance', 0.001)
+                    )
+                    res = array_len * bits_per_element
+                except Exception:
+                    res = classical_input.size
+            else:
+                res = classical_input.size
         elif isinstance(classical_input, ast.FloatType):
-            res = int(
-                classical_input.size.value
-                if hasattr(classical_input, "size") and classical_input.size
-                else 32
-            )
+            if input_value is not None:
+                try:
+                    v = float(input_value.value if hasattr(input_value, "value") else input_value)
+                    _, _, bits_per_element = self._calculate_fixed_point_params(
+                        [v], 
+                        getattr(node, 'decimalPrecision', None), 
+                        getattr(node, 'errorTolerance', 0.001)
+                    )
+                    res = bits_per_element
+                except (TypeError, ValueError):
+                    pass
+            if 'res' not in locals():
+                res = int(
+                    classical_input.size.value
+                    if hasattr(classical_input, "size") and classical_input.size
+                    else 32
+                )
         else:
             size = 0
             match classical_input:
                 case (
                     data_types.BoolType()
                     | data_types.IntType()
-                    | data_types.ArrayType()
                 ):
                     size = classical_input.size
                 case data_types.BitType():
                     size = classical_input.size or 1
                 case data_types.FloatType():
-                    size = (
-                        classical_input.size
-                        if hasattr(classical_input, "size") and classical_input.size
-                        else 32
-                    )
+                    if input_value is not None:
+                        try:
+                            v = float(input_value.value if hasattr(input_value, "value") else input_value)
+                            _, _, bits_per_element = self._calculate_fixed_point_params(
+                                [v], 
+                                getattr(node, 'decimalPrecision', None), 
+                                getattr(node, 'errorTolerance', 0.001)
+                            )
+                            size = bits_per_element
+                        except (TypeError, ValueError):
+                            pass
+                    if size == 0:
+                        size = (
+                            classical_input.size
+                            if hasattr(classical_input, "size") and classical_input.size
+                            else 32
+                        )
                 case _:
                     if hasattr(classical_input, "size") and isinstance(
                         classical_input.size, int
@@ -358,19 +439,21 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         return res
 
     def _float_to_fixed_point_indices(
-        self, value: float, element_size: int
+        self, value: float, element_size: int, fractional_bits: int
     ) -> list[int]:
         """
         Approximates a floating point number into a fixed-point binary representation
         and returns the indices of the '1' bits. Dynamically scales fractional precision.
         """
-        fractional_bits = element_size // 2
         scaled_value = round(value * (1 << fractional_bits))
+        if scaled_value < 0:
+            scaled_value = (1 << element_size) + scaled_value
         mask = scaled_value & ((1 << element_size) - 1)
         return [index for index in range(element_size) if (mask >> index) & 1]
 
     def _array_basis_indices(
         self,
+        node: CompileRequest.EncodeValueNode,
         classical_input: data_types.LeqoSupportedClassicalType,
         raw_value: Any,
     ) -> list[int]:
@@ -379,20 +462,17 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         element_type = self._get_element_type(classical_input)
 
         if isinstance(element_type, (data_types.FloatType, ast.FloatType)):
-            if hasattr(element_type, "size") and element_type.size:
-                element_size = int(
-                    element_type.size.value
-                    if hasattr(element_type.size, "value")
-                    else element_type.size
-                )
-            else:
-                element_size = 32
+            _, fractional_bits, element_size = self._calculate_fixed_point_params(
+                values, getattr(node, 'decimalPrecision', None), getattr(node, 'errorTolerance', 0.001)
+            )
 
             mask_limit = (1 << element_size) - 1
-            fractional_bits = element_size // 2
             indices: list[int] = []
             for element_index, element_value in enumerate(values):
                 scaled_val = round(float(element_value) * (1 << fractional_bits))
+                if scaled_val < 0:
+                    scaled_val = (1 << element_size) + scaled_val
+                    
                 mask = scaled_val & mask_limit
                 base_offset = element_index * element_size
                 indices.extend(
@@ -425,6 +505,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
 
     def _constant_basis_indices(
         self,
+        node: CompileRequest.EncodeValueNode,
         classical_input: data_types.LeqoSupportedClassicalType,
         register_size: int,
         raw_value: Any,
@@ -432,14 +513,17 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         if isinstance(classical_input, data_types.FloatType):
             try:
                 v = float(raw_value.value if hasattr(raw_value, "value") else raw_value)
-                return self._float_to_fixed_point_indices(v, register_size)
+                _, fractional_bits, element_size = self._calculate_fixed_point_params(
+                    [v], getattr(node, 'decimalPrecision', None), getattr(node, 'errorTolerance', 0.001)
+                )
+                return self._float_to_fixed_point_indices(v, element_size, fractional_bits)
             except (TypeError, ValueError) as exc:
                 raise RuntimeError(
                     "Unsupported float input for basis encoding"
                 ) from exc
 
         if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
-            return self._array_basis_indices(classical_input, raw_value)
+            return self._array_basis_indices(node, classical_input, raw_value)
 
         try:
             value = int(raw_value)

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -44,8 +44,8 @@ class _AngleEmissionContext:
 
 @dataclass
 class BasisMetadata:
-    vector_length: int
-    fractional_bits: int
+    vector_length: int = 1
+    fractional_bits: int = 0
 
 
 class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
@@ -444,9 +444,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         if decimal_precision is not None:
             frac_bits = ceil(decimal_precision * log2(10))
         else:
-            frac_bits = (
-                ceil(-log2(error_tolerance)) if error_tolerance < 1 else 0
-            )
+            frac_bits = ceil(-log2(error_tolerance)) if error_tolerance < 1 else 0
 
         total_bits_per_num = int_bits + frac_bits
         return int_bits, frac_bits, total_bits_per_num
@@ -658,26 +656,25 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         if raw_value is None:
             return False
 
+        result = False
         if isinstance(classical_input, data_types.IntType):
             try:
-                return int(raw_value) < 0
+                result = int(raw_value) < 0
             except (TypeError, ValueError):
-                return False
-
-        if isinstance(classical_input, (data_types.FloatType, ast.FloatType)):
+                result = False
+        elif isinstance(classical_input, (data_types.FloatType, ast.FloatType)):
             try:
-                return float(raw_value) < 0
+                result = float(raw_value) < 0
             except (TypeError, ValueError):
-                return False
-
-        if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
+                result = False
+        elif isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
             try:
                 values = self._coerce_array_constant_value(classical_input, raw_value)
-                return any(value < 0 for value in values)
+                result = any(value < 0 for value in values)
             except RuntimeError:
-                return False
+                result = False
 
-        return False
+        return result
 
     @staticmethod
     def _coerce_array_constant_value(

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -359,11 +359,12 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         array_len = self._get_array_length(classical_input)
         element_type = self._get_element_type(classical_input)
 
-        if isinstance(element_type, (data_types.FloatType, ast.FloatType)) and input_value is not None:
+        if (
+            isinstance(element_type, (data_types.FloatType, ast.FloatType))
+            and input_value is not None
+        ):
             try:
-                values = self._coerce_array_constant_value(
-                    classical_input, input_value
-                )
+                values = self._coerce_array_constant_value(classical_input, input_value)
                 _, _, bits_per_element = self._calculate_fixed_point_params(
                     values,
                     getattr(node, "decimalPrecision", None),
@@ -371,7 +372,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                 )
                 return array_len * bits_per_element
             except Exception:
-                    pass
+                pass
 
         if isinstance(classical_input, data_types.ArrayType):
             return classical_input.size

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -282,7 +282,9 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
             register_size = self._get_array_length(classical_input)
         else:
-            register_size = self._determine_register_size(node, classical_input, input_value)
+            register_size = self._determine_register_size(
+                node, classical_input, input_value
+            )
 
         rotation_map: dict[int, float] | None = None
         if input_value is not None:
@@ -307,7 +309,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             implementation(node, statements),
             ImplementationMetaData(width=register_size, depth=depth),
         )
-    
+
     def _calculate_fixed_point_params(
         self, values: list[float], decimal_precision: int | None, error_tolerance: float
     ) -> tuple[int, int, int]:
@@ -319,12 +321,14 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             return 1, 0, 1
 
         max_mag = max(abs(int(v)) for v in values)
-        int_bits = max(1, max_mag.bit_length() + 1) 
+        int_bits = max(1, max_mag.bit_length() + 1)
 
         if decimal_precision is not None:
             frac_bits = math.ceil(decimal_precision * math.log2(10))
         else:
-            frac_bits = math.ceil(-math.log2(error_tolerance)) if error_tolerance < 1 else 0
+            frac_bits = (
+                math.ceil(-math.log2(error_tolerance)) if error_tolerance < 1 else 0
+            )
 
         total_bits_per_num = int_bits + frac_bits
         return int_bits, frac_bits, total_bits_per_num
@@ -335,108 +339,96 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
         classical_input: data_types.LeqoSupportedClassicalType,
         input_value: Any | None = None,
     ) -> int:
-        res: int
-        if node.encoding == "angle" and not isinstance(
-            classical_input, (data_types.ArrayType, ast.ArrayType)
-        ):
-            res = 1
-        elif isinstance(classical_input, ast.ArrayType):
-            array_len = self._get_array_length(classical_input)
-            element_type = self._get_element_type(classical_input)
-            if isinstance(element_type, ast.FloatType) and input_value is not None:
-                try:
-                    values = self._coerce_array_constant_value(classical_input, input_value)
-                    _, _, bits_per_element = self._calculate_fixed_point_params(
-                        values, 
-                        getattr(node, 'decimalPrecision', None), 
-                        getattr(node, 'errorTolerance', 0.001)
-                    )
-                    res = array_len * bits_per_element
-                except Exception:
-                    res = array_len * 32
-            else:
-                if hasattr(element_type, "size") and element_type.size:
-                    size_val = element_type.size.value if hasattr(element_type.size, "value") else element_type.size
-                    res = array_len * int(size_val)
-                elif isinstance(element_type, ast.ArrayType) or hasattr(element_type, "value"):
-                    res = array_len * int(element_type.value)
-                else:
-                    res = array_len * 32
-        elif isinstance(classical_input, data_types.ArrayType):
-            element_type = self._get_element_type(classical_input)
-            if isinstance(element_type, data_types.FloatType) and input_value is not None:
-                try:
-                    array_len = self._get_array_length(classical_input)
-                    values = self._coerce_array_constant_value(classical_input, input_value)
-                    _, _, bits_per_element = self._calculate_fixed_point_params(
-                        values, 
-                        getattr(node, 'decimalPrecision', None), 
-                        getattr(node, 'errorTolerance', 0.001)
-                    )
-                    res = array_len * bits_per_element
-                except Exception:
-                    res = classical_input.size
-            else:
-                res = classical_input.size
-        elif isinstance(classical_input, ast.FloatType):
+        is_array = isinstance(classical_input, (data_types.ArrayType, ast.ArrayType))
+
+        if node.encoding == "angle":
+            if is_array:
+                return self._get_array_length(classical_input)
+            return 1
+
+        if is_array:
+            return self._determine_array_size(node, classical_input, input_value)
+
+        return self._determine_scalar_size(node, classical_input, input_value)
+
+    def _determine_array_size(
+        self,
+        node: CompileRequest.EncodeValueNode,
+        classical_input: Any,
+        input_value: Any | None,
+    ) -> int:
+        array_len = self._get_array_length(classical_input)
+        element_type = self._get_element_type(classical_input)
+
+        if isinstance(element_type, (data_types.FloatType, ast.FloatType)):
             if input_value is not None:
                 try:
-                    v = float(input_value.value if hasattr(input_value, "value") else input_value)
-                    _, _, bits_per_element = self._calculate_fixed_point_params(
-                        [v], 
-                        getattr(node, 'decimalPrecision', None), 
-                        getattr(node, 'errorTolerance', 0.001)
+                    values = self._coerce_array_constant_value(
+                        classical_input, input_value
                     )
-                    res = bits_per_element
+                    _, _, bits_per_element = self._calculate_fixed_point_params(
+                        values,
+                        getattr(node, "decimalPrecision", None),
+                        getattr(node, "errorTolerance", 0.001),
+                    )
+                    return array_len * bits_per_element
+                except Exception:
+                    pass
+
+        if isinstance(classical_input, data_types.ArrayType):
+            return classical_input.size
+
+        if hasattr(element_type, "size") and element_type.size:
+            size_val = (
+                element_type.size.value
+                if hasattr(element_type.size, "value")
+                else element_type.size
+            )
+            return array_len * int(size_val)
+
+        return array_len * 32
+
+    def _determine_scalar_size(
+        self,
+        node: CompileRequest.EncodeValueNode,
+        classical_input: Any,
+        input_value: Any | None,
+    ) -> int:
+        if isinstance(classical_input, (data_types.FloatType, ast.FloatType)):
+            if input_value is not None:
+                try:
+                    v = float(
+                        input_value.value
+                        if hasattr(input_value, "value")
+                        else input_value
+                    )
+                    _, _, bits_per_element = self._calculate_fixed_point_params(
+                        [v],
+                        getattr(node, "decimalPrecision", None),
+                        getattr(node, "errorTolerance", 0.001),
+                    )
+                    return bits_per_element
                 except (TypeError, ValueError):
                     pass
-            if 'res' not in locals():
-                res = int(
+            if isinstance(classical_input, ast.FloatType):
+                return int(
                     classical_input.size.value
                     if hasattr(classical_input, "size") and classical_input.size
                     else 32
                 )
-        else:
-            size = 0
-            match classical_input:
-                case (
-                    data_types.BoolType()
-                    | data_types.IntType()
-                ):
-                    size = classical_input.size
-                case data_types.BitType():
-                    size = classical_input.size or 1
-                case data_types.FloatType():
-                    if input_value is not None:
-                        try:
-                            v = float(input_value.value if hasattr(input_value, "value") else input_value)
-                            _, _, bits_per_element = self._calculate_fixed_point_params(
-                                [v], 
-                                getattr(node, 'decimalPrecision', None), 
-                                getattr(node, 'errorTolerance', 0.001)
-                            )
-                            size = bits_per_element
-                        except (TypeError, ValueError):
-                            pass
-                    if size == 0:
-                        size = (
-                            classical_input.size
-                            if hasattr(classical_input, "size") and classical_input.size
-                            else 32
-                        )
-                case _:
-                    if hasattr(classical_input, "size") and isinstance(
-                        classical_input.size, int
-                    ):
-                        size = classical_input.size
-                    else:
-                        raise InputTypeMismatch(
-                            node, 0, actual=classical_input, expected="classical type"
-                        )
-            if size <= 0:
-                raise InputSizeMismatch(node, 0, actual=size, expected=1)
-            res = size
-        return res
+            return getattr(classical_input, "size", 32) or 32
+
+        if isinstance(classical_input, (data_types.IntType, data_types.BoolType)):
+            return classical_input.size
+        if isinstance(classical_input, data_types.BitType):
+            return classical_input.size or 1
+
+        if hasattr(classical_input, "size") and isinstance(classical_input.size, int):
+            return classical_input.size
+
+        raise InputTypeMismatch(
+            node, 0, actual=classical_input, expected="classical type"
+        )
 
     def _float_to_fixed_point_indices(
         self, value: float, element_size: int, fractional_bits: int
@@ -463,7 +455,9 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
 
         if isinstance(element_type, (data_types.FloatType, ast.FloatType)):
             _, fractional_bits, element_size = self._calculate_fixed_point_params(
-                values, getattr(node, 'decimalPrecision', None), getattr(node, 'errorTolerance', 0.001)
+                values,
+                getattr(node, "decimalPrecision", None),
+                getattr(node, "errorTolerance", 0.001),
             )
 
             mask_limit = (1 << element_size) - 1
@@ -472,7 +466,7 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                 scaled_val = round(float(element_value) * (1 << fractional_bits))
                 if scaled_val < 0:
                     scaled_val = (1 << element_size) + scaled_val
-                    
+
                 mask = scaled_val & mask_limit
                 base_offset = element_index * element_size
                 indices.extend(
@@ -514,9 +508,13 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
             try:
                 v = float(raw_value.value if hasattr(raw_value, "value") else raw_value)
                 _, fractional_bits, element_size = self._calculate_fixed_point_params(
-                    [v], getattr(node, 'decimalPrecision', None), getattr(node, 'errorTolerance', 0.001)
+                    [v],
+                    getattr(node, "decimalPrecision", None),
+                    getattr(node, "errorTolerance", 0.001),
                 )
-                return self._float_to_fixed_point_indices(v, element_size, fractional_bits)
+                return self._float_to_fixed_point_indices(
+                    v, element_size, fractional_bits
+                )
             except (TypeError, ValueError) as exc:
                 raise RuntimeError(
                     "Unsupported float input for basis encoding"

--- a/app/enricher/encode_value.py
+++ b/app/enricher/encode_value.py
@@ -642,6 +642,12 @@ class EncodeValueEnricherStrategy(DataBaseEnricherStrategy):
                 return int(raw_value) < 0
             except (TypeError, ValueError):
                 return False
+            
+        if isinstance(classical_input, (data_types.FloatType, ast.FloatType)):
+            try:
+                return float(raw_value) < 0
+            except (TypeError, ValueError):
+                return False
 
         if isinstance(classical_input, (data_types.ArrayType, ast.ArrayType)):
             try:

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -117,7 +117,7 @@ class EncodeValueNode(BaseNode):
 
     decimalPrecision: int | None = Field(default=None, ge=1)
     """User-defined number of decimal places for float encoding."""
-    
+
     errorTolerance: float = Field(default=0.001, gt=0)
     """Fallback tolerance if decimal precision is not provided."""
 

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -115,6 +115,12 @@ class EncodeValueNode(BaseNode):
     bounds: int = Field(ge=0, default=0, le=1)
     """Indicates whether values are clamped (0 or 1)."""
 
+    decimalPrecision: int | None = Field(default=None, ge=1)
+    """User-defined number of decimal places for float encoding."""
+    
+    errorTolerance: float = Field(default=0.001, gt=0)
+    """Fallback tolerance if decimal precision is not provided."""
+
     model_config = ConfigDict(use_attribute_docstrings=True)
 
 

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -115,7 +115,7 @@ class EncodeValueNode(BaseNode):
     bounds: int = Field(ge=0, default=0, le=1)
     """Indicates whether values are clamped (0 or 1)."""
 
-    decimalPrecision: int | None = Field(default=None, ge=1)
+    decimalPrecision: int | None = Field(default=None, ge=0)
     """User-defined number of decimal places for float encoding."""
 
     errorTolerance: float = Field(default=0.001, gt=0)

--- a/tests/enricher/test_encode_value.py
+++ b/tests/enricher/test_encode_value.py
@@ -647,12 +647,6 @@ async def test_enrich_angle_encode_value_array_input(engine: AsyncEngine) -> Non
 
 @pytest.mark.asyncio
 async def test_enrich_encode_value_float_precision(engine: AsyncEngine) -> None:
-    """
-    Tests if the encode_value properly uses the decimalPrecision parameter
-    to reduce the required qubits, and accurately assigns the structural metadata
-    to the generated register so the bitstring can be safely decoded.
-    """
-    # 1. Clear the database cache to force dynamic AST generation
     async with AsyncSession(engine) as session:
         await session.execute(
             delete(EncodeValueNode).where(
@@ -686,12 +680,53 @@ async def test_enrich_encode_value_float_precision(engine: AsyncEngine) -> None:
         else leqo_dumps(implementation)
     )
 
-    # 2. Structural properties preserved!
     assert "@leqo.twos_complement true" in implementation_str
     assert "@leqo.length 1" in implementation_str
-
-    # math.ceil(2 * log2(10)) -> math.ceil(2 * 3.32) -> 7
     assert "@leqo.fractional_bits 7" in implementation_str
-
-    # 3. Total bits verification (abs(-2) -> max_mag=2 -> int_bits=3. Total: 3 + 7 = 10)
     assert "qubit[10] encoded;" in implementation_str
+
+
+@pytest.mark.asyncio
+async def test_enrich_encode_value_float_array_precision(
+    engine: AsyncEngine,
+) -> None:
+    async with AsyncSession(engine) as session:
+        await session.execute(
+            delete(EncodeValueNode).where(
+                EncodeValueNode.encoding == EncodingType.BASIS
+            )
+        )
+        await session.commit()
+
+    node = FrontendEncodeValueNode(
+        id="1",
+        label=None,
+        type="encode",
+        encoding="basis",
+        bounds=1,
+        decimalPrecision=2,
+    )
+    array_type = ArrayType.with_size(32, 3, is_float=True)
+    expected_width = 33
+    constraints = Constraints(
+        requested_inputs={0: array_type},
+        requested_input_values={0: [-2.1, 0.4, 6.9]},
+        optimizeDepth=True,
+        optimizeWidth=True,
+    )
+
+    results = list(await EncodeValueEnricherStrategy(engine).enrich(node, constraints))
+    assert len(results) == 1
+
+    implementation = results[0].enriched_node.implementation
+    implementation_str = (
+        implementation
+        if isinstance(implementation, str)
+        else leqo_dumps(implementation)
+    )
+
+    assert "@leqo.twos_complement true" in implementation_str
+    assert "@leqo.length 3" in implementation_str
+    assert "@leqo.fractional_bits 7" in implementation_str
+    assert f"qubit[{expected_width}] encoded;" in implementation_str
+    assert results[0].meta_data.width == expected_width

--- a/tests/enricher/test_encode_value.py
+++ b/tests/enricher/test_encode_value.py
@@ -1,5 +1,5 @@
-import re
 import math
+import re
 
 import pytest
 import pytest_asyncio
@@ -585,9 +585,9 @@ async def test_enrich_angle_encode_value_array_literal(engine: AsyncEngine) -> N
     expected_rotations = [
         2 * (((v - min_v) / (max_v - min_v)) * (math.pi / 2))
         for v in array_values
-        if v != min_v # Skips 0.0 rotations, just like the compiler does!
+        if v != min_v
     ]
-    
+
     rotation_args = [
         arg.strip() for arg in re.findall(r"ry\(([^)]+)\)", implementation_str)
     ]

--- a/tests/enricher/test_encode_value.py
+++ b/tests/enricher/test_encode_value.py
@@ -1,4 +1,5 @@
 import re
+import math
 
 import pytest
 import pytest_asyncio
@@ -456,12 +457,12 @@ async def test_enrich_angle_encode_value_node_not_in_db(engine: AsyncEngine) -> 
 
     assert "@leqo.input 0" in implementation_str
     assert "int[32] value;" in implementation_str
-    assert "qubit[32] encoded;" in implementation_str
-    assert implementation_str.count("ry(3.141592653589793)") == ENCODE_REGISTER_SIZE
+    assert "qubit[1] encoded;" in implementation_str
+    assert implementation_str.count("ry(3.141592653589793)") == 1
     assert "@leqo.output 0" in implementation_str
     assert "let out = encoded;" in implementation_str
-    assert result.meta_data.width == ENCODE_REGISTER_SIZE
-    assert result.meta_data.depth == ENCODE_REGISTER_SIZE
+    assert result.meta_data.width == 1
+    assert result.meta_data.depth == 1
 
 
 @pytest.mark.asyncio
@@ -579,12 +580,14 @@ async def test_enrich_angle_encode_value_array_literal(engine: AsyncEngine) -> N
     assert "array[int[3], 2] value;" not in implementation_str
     assert "if" not in implementation_str
     assert f"qubit[{array_type.length}] encoded;" in implementation_str
-    mask_limit = (1 << array_type.element_type.size) - 1
+    min_v = min(array_values)
+    max_v = max(array_values)
     expected_rotations = [
-        2 * float(value & mask_limit)
-        for value in array_values
-        if (value & mask_limit) != 0
+        2 * (((v - min_v) / (max_v - min_v)) * (math.pi / 2))
+        for v in array_values
+        if v != min_v # Skips 0.0 rotations, just like the compiler does!
     ]
+    
     rotation_args = [
         arg.strip() for arg in re.findall(r"ry\(([^)]+)\)", implementation_str)
     ]

--- a/tests/enricher/test_encode_value.py
+++ b/tests/enricher/test_encode_value.py
@@ -1,4 +1,3 @@
-import math
 import re
 from math import sqrt
 

--- a/tests/enricher/test_encode_value.py
+++ b/tests/enricher/test_encode_value.py
@@ -299,6 +299,7 @@ async def test_enrich_encode_value_bit_literal(engine: AsyncEngine) -> None:
     assert "qubit[1] encoded;" in implementation_str
     assert implementation_str.count("x encoded[0];") == 1
     assert "@leqo.output 0" in implementation_str
+    assert "@leqo.length 1" in implementation_str
     assert result.meta_data.width == 1
     assert result.meta_data.depth == 1
 
@@ -337,6 +338,7 @@ async def test_enrich_encode_value_node_not_in_db(engine: AsyncEngine) -> None:
     assert "x encoded[0];" in implementation_str
     assert "x encoded[31];" in implementation_str
     assert "@leqo.output 0" in implementation_str
+    assert "@leqo.length 1" in implementation_str
     assert "let out = encoded;" in implementation_str
     assert result.meta_data.width == ENCODE_REGISTER_SIZE
     assert result.meta_data.depth == ENCODE_REGISTER_SIZE
@@ -381,6 +383,7 @@ async def test_enrich_encode_value_node_not_in_db_with_literal_value(
     assert implementation_str.count("x encoded[2];") == 1
     assert "x encoded[1];" not in implementation_str
     assert "@leqo.output 0" in implementation_str
+    assert "@leqo.length 1" in implementation_str
     assert "@leqo.twos_complement true" not in implementation_str
     assert "let out = encoded;" in implementation_str
     assert result.meta_data.width == expected_width
@@ -417,6 +420,7 @@ async def test_enrich_basis_encode_negative_literal_sets_signed_output(
     )
 
     assert "@leqo.output 0" in implementation_str
+    assert "@leqo.length 1" in implementation_str
     assert "@leqo.twos_complement true" in implementation_str
 
 
@@ -502,6 +506,9 @@ async def test_enrich_encode_value_array_literal(engine: AsyncEngine) -> None:
     assert f"qubit[{total_size}] encoded;" in implementation_str
     for index in (0, 4, 5):
         assert f"x encoded[{index}];" in implementation_str
+    
+    assert "@leqo.length 2" in implementation_str
+    
     expected_depth = sum(
         (value & ((1 << element_size) - 1)).bit_count() for value in array_values
     )
@@ -542,6 +549,7 @@ async def test_enrich_encode_value_array_input(engine: AsyncEngine) -> None:
     assert f"qubit[{array_type.size}] encoded;" in implementation_str
     assert implementation_str.count("if") == array_type.size
     assert "@leqo.output 0" in implementation_str
+    assert "@leqo.length 2" in implementation_str
     assert result.meta_data.width == array_type.size
     assert result.meta_data.depth == array_type.size
 
@@ -644,3 +652,55 @@ async def test_enrich_angle_encode_value_array_input(engine: AsyncEngine) -> Non
     assert "@leqo.output 0" in implementation_str
     assert result.meta_data.width == array_type.length
     assert result.meta_data.depth == array_type.length
+
+
+@pytest.mark.asyncio
+async def test_enrich_encode_value_float_precision(engine: AsyncEngine) -> None:
+    """
+    Tests if the encode_value properly uses the decimalPrecision parameter
+    to reduce the required qubits, and accurately assigns the structural metadata
+    to the generated register so the bitstring can be safely decoded.
+    """
+    # 1. Clear the database cache to force dynamic AST generation
+    async with AsyncSession(engine) as session:
+        await session.execute(
+            delete(EncodeValueNode).where(
+                EncodeValueNode.encoding == EncodingType.BASIS
+            )
+        )
+        await session.commit()
+
+    node = FrontendEncodeValueNode(
+        id="1",
+        label=None,
+        type="encode",
+        encoding="basis",
+        bounds=1,
+        decimalPrecision=2,
+    )
+    constraints = Constraints(
+        requested_inputs={0: FloatType(size=32)},
+        requested_input_values={0: -2.1},
+        optimizeDepth=True,
+        optimizeWidth=True,
+    )
+
+    results = list(await EncodeValueEnricherStrategy(engine).enrich(node, constraints))
+    assert len(results) == 1
+
+    implementation = results[0].enriched_node.implementation
+    implementation_str = (
+        implementation
+        if isinstance(implementation, str)
+        else leqo_dumps(implementation)
+    )
+
+    # 2. Structural properties preserved!
+    assert "@leqo.twos_complement true" in implementation_str
+    assert "@leqo.length 1" in implementation_str
+    
+    # math.ceil(2 * log2(10)) -> math.ceil(2 * 3.32) -> 7
+    assert "@leqo.fractional_bits 7" in implementation_str
+
+    # 3. Total bits verification (abs(-2) -> max_mag=2 -> int_bits=3. Total: 3 + 7 = 10)
+    assert "qubit[10] encoded;" in implementation_str


### PR DESCRIPTION
Fixed float array issue for basis-encoding, now two's complement logics is used here too. test case:

input: [-2.1, 0.4, 6.9]
output:
OPENQASM 3.1;
include "stdgates.inc";
qubit[96] leqo_reg;
/* Start node 5ca14866-cb3d-4e6c-8eb7-d1742598cb52 */
array[float[32], 3] leqo_4a23b070c3c858acb96779a8ed4adf96_literal = {-2.1, 0.4, 6.9};
@leqo.output 0
let leqo_4a23b070c3c858acb96779a8ed4adf96_out = leqo_4a23b070c3c858acb96779a8ed4adf96_literal;
/* End node 5ca14866-cb3d-4e6c-8eb7-d1742598cb52 */
/* Start node 106d468e-7224-47cd-a4ec-90c878cfdd6b */
let leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded = leqo_reg[{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95}];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[1];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[2];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[5];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[6];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[9];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[10];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[13];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[14];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[15];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[16];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[18];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[19];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[20];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[21];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[22];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[23];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[24];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[25];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[26];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[27];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[28];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[29];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[30];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[31];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[33];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[34];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[37];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[38];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[41];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[42];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[45];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[46];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[65];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[66];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[69];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[70];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[73];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[74];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[77];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[78];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[79];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[81];
x leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded[82];
@leqo.output 0
@leqo.twos_complement true
let leqo_f7218f1972f15ee78cc32d7c6d46d680_out = leqo_f7218f1972f15ee78cc32d7c6d46d680_encoded;
/* End node 106d468e-7224-47cd-a4ec-90c878cfdd6b */
