### PR TITLE
Add P gate support

### DIFF
--- a/app/openqasm3/stdgates.py
+++ b/app/openqasm3/stdgates.py
@@ -10,6 +10,6 @@ OneQubitGate = Literal["x", "y", "z", "h", "s", "sdg", "t", "tdg", "sx"]
 TwoQubitGate = Literal["cx", "cy", "cz", "ch", "swap"]
 ThreeQubitGate = Literal["ccx"]
 
-OneQubitGateWithAngle = Literal["rx", "ry", "rz"]
+OneQubitGateWithAngle = Literal["rx", "ry", "rz", "p"]
 TwoQubitGateWithParam = Literal["cp"]
 TwoQubitGateWithAngle = Literal["crx", "cry", "crz"]

--- a/tests/enricher/test_p_gate.py
+++ b/tests/enricher/test_p_gate.py
@@ -1,12 +1,23 @@
+import pytest
+
 from app.enricher import Constraints
 from app.enricher.gates import GateEnricherStrategy
 from app.model.CompileRequest import ParameterizedGateNode
-from app.model.data_types import QubitType
+from app.model.data_types import IntType, QubitType
+from app.model.exceptions import InputCountMismatch, InputTypeMismatch
 from tests.enricher.utils import assert_enrichment
 
 
-def test_p_gate_is_mapped_to_qasm() -> None:
-    node = ParameterizedGateNode(id="nodeId", gate="p", parameter=0.1)
+@pytest.mark.parametrize(
+    "parameter",
+    [
+        0.1,
+        0.0,
+        -0.1,
+    ],
+)
+def test_p_gate_is_mapped_to_qasm(parameter: float) -> None:
+    node = ParameterizedGateNode(id="nodeId", gate="p", parameter=parameter)
     constraints = Constraints(
         requested_inputs={0: QubitType(3)},
         optimizeWidth=False,
@@ -22,13 +33,53 @@ def test_p_gate_is_mapped_to_qasm() -> None:
     assert_enrichment(
         result,
         "nodeId",
-        """\
+        f"""\
         OPENQASM 3.1;
         include "stdgates.inc";
         @leqo.input 0
         qubit[3] q0;
-        p(0.1) q0;
+        p({parameter}) q0;
         @leqo.output 0
         let q0_out = q0;
         """,
     )
+
+
+@pytest.mark.parametrize(
+    ("requested_inputs", "expected_actual_count"),
+    [
+        ({}, 0),
+        ({0: QubitType(3), 1: QubitType(3)}, 2),
+    ],
+)
+def test_p_gate_requires_exactly_one_input(
+    requested_inputs: dict[int, QubitType],
+    expected_actual_count: int,
+) -> None:
+    node = ParameterizedGateNode(id="nodeId", gate="p", parameter=0.1)
+    constraints = Constraints(
+        requested_inputs=requested_inputs,
+        optimizeWidth=False,
+        optimizeDepth=False,
+    )
+
+    with pytest.raises(
+        InputCountMismatch,
+        match=rf"^Node should have 1 inputs\. Got {expected_actual_count}\.$",
+    ):
+        GateEnricherStrategy()._enrich_parameterized_gate(node, constraints)
+
+
+def test_p_gate_rejects_non_qubit_input() -> None:
+    node = ParameterizedGateNode(id="nodeId", gate="p", parameter=0.1)
+    constraints = Constraints(
+        requested_inputs={0: IntType(32)},
+        optimizeWidth=False,
+        optimizeDepth=False,
+    )
+
+    with pytest.raises(
+        InputTypeMismatch,
+        match=r"^Expected type 'qubit' for input 0\.",
+    ):
+        GateEnricherStrategy()._enrich_parameterized_gate(node, constraints)

--- a/tests/enricher/test_p_gate.py
+++ b/tests/enricher/test_p_gate.py
@@ -1,0 +1,34 @@
+from app.enricher import Constraints
+from app.enricher.gates import GateEnricherStrategy
+from app.model.CompileRequest import ParameterizedGateNode
+from app.model.data_types import QubitType
+from tests.enricher.utils import assert_enrichment
+
+
+def test_p_gate_is_mapped_to_qasm() -> None:
+    node = ParameterizedGateNode(id="nodeId", gate="p", parameter=0.1)
+    constraints = Constraints(
+        requested_inputs={0: QubitType(3)},
+        optimizeWidth=False,
+        optimizeDepth=False,
+    )
+
+    result = (
+        GateEnricherStrategy()
+        ._enrich_parameterized_gate(node, constraints)
+        .enriched_node
+    )
+
+    assert_enrichment(
+        result,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        include "stdgates.inc";
+        @leqo.input 0
+        qubit[3] q0;
+        p(0.1) q0;
+        @leqo.output 0
+        let q0_out = q0;
+        """,
+    )


### PR DESCRIPTION
Adds backend support for the parameterized single-qubit `p` gate.

`P(λ)` exists in the frontend constants, but backend support for the `p` gate was missing.

#Changes

- Added `p` to the supported single-qubit parameterized gate definitions.
- Added a dedicated backend test for the generated QASM output.

#Expected QASM

#```qasm
p(0.1) q0;


# Definition of Done

- [x] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [x] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [x] **Peer Review**: The code has undergone peer review by another team member.
- [x] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [x] **Deployment Readiness**: The work is ready for deployment to production if needed.

