### PR TITLE
Add inverse property to QFT node

### DIFF
--- a/app/enricher/qft.py
+++ b/app/enricher/qft.py
@@ -196,7 +196,7 @@ class QFTEnricherStrategy(EnricherStrategy):
         statements = [
             Include("stdgates.inc"),
             leqo_input("q", 0, size),
-            *_build_qft_statements(size, inverse=False),
+            *_build_qft_statements(size, inverse=node.inverse),
             leqo_output("q_out", 0, Identifier("q")),
         ]
 

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -326,6 +326,9 @@ class QFTNode(BaseNode):
     size: int | None = Field(default=None, gt=0)
     """Number of qubits the QFT acts on."""
 
+    inverse: bool = False
+    """Whether to generate the inverse Quantum Fourier Transform."""
+
     model_config = ConfigDict(use_attribute_docstrings=True)
 
 


### PR DESCRIPTION

This PR adds an `inverse` property to the QFT node so that the frontend can request inverse QFT directly.

The property defaults to `false`, so the existing QFT behavior remains unchanged.

When `inverse` is set to `true`, the QFT enricher passes this value to the existing QFT helper and generates the inverse QFT gate sequence.

Input and output structure stay the same:
- one qubit register input
- one qubit register output with the same size





# Definition of Done

- [ ] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [ ] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [ ] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [ ] **Deployment Readiness**: The work is ready for deployment to production if needed.
