### PR TITLE
Add dynamic quantum bitwise NOT operator

### DIFF
--- a/app/enricher/operator.py
+++ b/app/enricher/operator.py
@@ -86,10 +86,49 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
                 node, 1, actual=requested_inputs[1], expected="qubit"
             )
 
+    def _check_unary_qubit_constraints(
+        self,
+        node: OperatorNode,
+        requested_inputs: dict[int, LeqoSupportedType],
+    ) -> QubitType:
+        """
+        Checks constraints for unary quantum operators such as bitwise NOT.
+        """
+
+        if len(requested_inputs) != 1:
+            raise InputCountMismatch(
+                node,
+                actual=len(requested_inputs),
+                should_be="equal",
+                expected=1,
+            )
+
+        input_type = requested_inputs.get(0)
+        if not isinstance(input_type, QubitType):
+            raise InputTypeMismatch(
+                node,
+                0,
+                actual=input_type,
+                expected="qubit",
+            )
+
+        return input_type
+
     @override
     async def _enrich_impl(
         self, node: FrontendNode, constraints: Constraints | None
     ) -> list[EnrichmentResult]:
+        if isinstance(node, OperatorNode) and node.operator == "~":
+            if constraints is None:
+                raise InputCountMismatch(
+                    node,
+                    actual=0,
+                    should_be="equal",
+                    expected=1,
+                )
+
+            return [self._generate_bitwise_not_enrichment(node, constraints)]
+
         if isinstance(node, OperatorNode) and node.operator == "+":
             dynamic_exception: Exception | None = None
             if constraints is not None:
@@ -171,6 +210,56 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
         return EnrichmentResult(
             enriched_node,
             ImplementationMetaData(width=width, depth=depth),
+        )
+
+    def _generate_bitwise_not_enrichment(
+        self,
+        node: OperatorNode,
+        constraints: Constraints,
+    ) -> EnrichmentResult:
+        requested_input = self._check_unary_qubit_constraints(
+            node,
+            constraints.requested_inputs,
+        )
+
+        declared_size = requested_input.size
+        effective_size = declared_size or 1
+        input_name = "operand"
+
+        statements: list[Statement] = [
+            Include("stdgates.inc"),
+            leqo_input(
+                input_name,
+                0,
+                declared_size,
+                twos_complement=requested_input.signed,
+            ),
+        ]
+
+        statements.extend(
+            QuantumGate(
+                modifiers=[],
+                name=Identifier("x"),
+                arguments=[],
+                qubits=[target],
+                duration=None,
+            )
+            for target in self._build_qubit_references(
+                input_name,
+                declared_size,
+                effective_size,
+            )
+        )
+
+        output_alias = leqo_output("out", 0, Identifier(input_name))
+        if requested_input.signed:
+            output_alias.annotations.append(Annotation("leqo.twos_complement", "true"))
+
+        statements.append(output_alias)
+
+        return EnrichmentResult(
+            implementation(node, statements),
+            ImplementationMetaData(width=effective_size, depth=1),
         )
 
     async def _fetch_operator_without_size_constraints(

--- a/tests/enricher/test_quantum_bitwise_operator.py
+++ b/tests/enricher/test_quantum_bitwise_operator.py
@@ -1,0 +1,66 @@
+import pytest
+from openqasm3.ast import QuantumGate
+
+from app.enricher import Constraints
+from app.enricher.operator import OperatorEnricherStrategy
+from app.model.CompileRequest import OperatorNode
+from app.model.data_types import QubitType
+from app.model.exceptions import InputCountMismatch, InputTypeMismatch
+
+REGISTER_SIZE = 3
+EXPECTED_DEPTH = 1
+EXPECTED_GATE_COUNT = 3
+
+
+def _only_quantum_gates(statements):
+    return [stmt for stmt in statements if isinstance(stmt, QuantumGate)]
+
+
+@pytest.mark.asyncio
+async def test_dynamic_quantum_bitwise_not_generates_x_gates(engine) -> None:
+    node = OperatorNode(id="not_1", type="operator", operator="~")
+    constraints = Constraints(
+        requested_inputs={0: QubitType(size=REGISTER_SIZE)},
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+
+    results = await strategy._enrich_impl(node, constraints)
+
+    assert len(results) == 1
+
+    result = results[0]
+    statements = result.enriched_node.implementation.statements
+    gates = _only_quantum_gates(statements)
+
+    assert result.meta_data.width == REGISTER_SIZE
+    assert result.meta_data.depth == EXPECTED_DEPTH
+    assert len(gates) == EXPECTED_GATE_COUNT
+    assert [gate.name.name for gate in gates] == ["x", "x", "x"]
+
+
+def test_dynamic_quantum_bitwise_not_requires_one_input(engine) -> None:
+    node = OperatorNode(id="not_1", type="operator", operator="~")
+    constraints = Constraints(
+        requested_inputs={},
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+
+    with pytest.raises(InputCountMismatch):
+        strategy._generate_bitwise_not_enrichment(node, constraints)
+
+
+def test_dynamic_quantum_bitwise_not_requires_qubit_input(engine) -> None:
+    node = OperatorNode(id="not_1", type="operator", operator="~")
+    constraints = Constraints(
+        requested_inputs={0: object()},
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+
+    with pytest.raises(InputTypeMismatch):
+        strategy._generate_bitwise_not_enrichment(node, constraints)


### PR DESCRIPTION
Previously, quantum bitwise operators were DB-backed only. This change adds dynamic generation for the unary NOT operator (`~`).

Behavior:
- accepts one qubit register input
- applies an `x` gate to every qubit in the input register
- returns the same register as output
- preserves the two's-complement annotation for signed qubit registers

Example:
input: qubit[3]
operator: ~

generated logic:
x operand[0]
x operand[1]
x operand[2]

This is intended as the first small dynamic implementation for the Quantum Bitwise Operator task.







# Definition of Done

- [ ] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [ ] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [ ] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [ ] **Deployment Readiness**: The work is ready for deployment to production if needed.
