### PR TITLE
Add dynamic quantum equality operator

### DIFF
--- a/app/enricher/operator.py
+++ b/app/enricher/operator.py
@@ -33,7 +33,11 @@ from app.model.CompileRequest import (
     Node as FrontendNode,
 )
 from app.model.data_types import LeqoSupportedType, QubitType
-from app.model.exceptions import InputCountMismatch, InputTypeMismatch
+from app.model.exceptions import (
+    InputCountMismatch,
+    InputSizeMismatch,
+    InputTypeMismatch,
+)
 
 
 @dataclass(frozen=True)
@@ -90,6 +94,17 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
     async def _enrich_impl(
         self, node: FrontendNode, constraints: Constraints | None
     ) -> list[EnrichmentResult]:
+        if isinstance(node, OperatorNode) and node.operator == "==":
+            if constraints is None:
+                raise InputCountMismatch(
+                    node,
+                    actual=0,
+                    should_be="equal",
+                    expected=2,
+                )
+
+            return [self._generate_equality_enrichment(node, constraints)]
+
         if isinstance(node, OperatorNode) and node.operator == "+":
             dynamic_exception: Exception | None = None
             if constraints is not None:
@@ -171,6 +186,69 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
         return EnrichmentResult(
             enriched_node,
             ImplementationMetaData(width=width, depth=depth),
+        )
+
+    def _generate_equality_enrichment(
+        self,
+        node: OperatorNode,
+        constraints: Constraints,
+    ) -> EnrichmentResult:
+        requested_inputs = constraints.requested_inputs
+        self._check_constraints(node, requested_inputs)
+
+        lhs = cast(QubitType, requested_inputs[0])
+        rhs = cast(QubitType, requested_inputs[1])
+
+        lhs_size = lhs.size or 1
+        rhs_size = rhs.size or 1
+
+        if lhs_size != 1:
+            raise InputSizeMismatch(node, 0, actual=lhs_size, expected=1)
+
+        if rhs_size != 1:
+            raise InputSizeMismatch(node, 1, actual=rhs_size, expected=1)
+
+        lhs_name = "lhs"
+        rhs_name = "rhs"
+        result_name = "result"
+
+        lhs_ref = self._build_qubit_references(lhs_name, lhs.size, lhs_size)[0]
+        rhs_ref = self._build_qubit_references(rhs_name, rhs.size, rhs_size)[0]
+        result_ref = Identifier(result_name)
+
+        statements: list[Statement] = [
+            Include("stdgates.inc"),
+            leqo_input(
+                lhs_name,
+                0,
+                lhs.size,
+                twos_complement=lhs.signed,
+            ),
+            leqo_input(
+                rhs_name,
+                1,
+                rhs.size,
+                twos_complement=rhs.signed,
+            ),
+            QubitDeclaration(
+                result_ref,
+                IntegerLiteral(1),
+            ),
+            QuantumGate(
+                modifiers=[],
+                name=Identifier("x"),
+                arguments=[],
+                qubits=[result_ref],
+                duration=None,
+            ),
+            self._cx_gate(lhs_ref, result_ref),
+            self._cx_gate(rhs_ref, result_ref),
+            leqo_output("out", 0, result_ref),
+        ]
+
+        return EnrichmentResult(
+            implementation(node, statements),
+            ImplementationMetaData(width=3, depth=3),
         )
 
     async def _fetch_operator_without_size_constraints(

--- a/tests/enricher/test_quantum_comparison_operator.py
+++ b/tests/enricher/test_quantum_comparison_operator.py
@@ -1,0 +1,97 @@
+import pytest
+from openqasm3.ast import QuantumGate
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from app.enricher import Constraints
+from app.enricher.operator import OperatorEnricherStrategy
+from app.model.CompileRequest import OperatorNode
+from app.model.data_types import FloatType, QubitType
+from app.model.exceptions import (
+    InputCountMismatch,
+    InputSizeMismatch,
+    InputTypeMismatch,
+)
+
+EXPECTED_WIDTH = 3
+EXPECTED_DEPTH = 3
+SINGLE_QUBIT_SIZE = 1
+INVALID_REGISTER_SIZE = 2
+
+
+def _only_quantum_gates(statements: list[object]) -> list[QuantumGate]:
+    return [stmt for stmt in statements if isinstance(stmt, QuantumGate)]
+
+
+@pytest.mark.asyncio
+async def test_dynamic_quantum_equality_generates_expected_gates(
+    engine: AsyncEngine,
+) -> None:
+    node = OperatorNode(id="eq_1", type="operator", operator="==")
+    constraints = Constraints(
+        requested_inputs={
+            0: QubitType(size=SINGLE_QUBIT_SIZE),
+            1: QubitType(size=SINGLE_QUBIT_SIZE),
+        },
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+
+    results = await strategy._enrich_impl(node, constraints)
+
+    assert len(results) == 1
+
+    result = results[0]
+    statements = result.enriched_node.implementation.statements
+    gates = _only_quantum_gates(statements)
+
+    assert result.meta_data.width == EXPECTED_WIDTH
+    assert result.meta_data.depth == EXPECTED_DEPTH
+    assert [gate.name.name for gate in gates] == ["x", "cx", "cx"]
+
+
+def test_dynamic_quantum_equality_requires_two_inputs(engine: AsyncEngine) -> None:
+    node = OperatorNode(id="eq_1", type="operator", operator="==")
+    constraints = Constraints(
+        requested_inputs={0: QubitType(size=SINGLE_QUBIT_SIZE)},
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+
+    with pytest.raises(InputCountMismatch):
+        strategy._generate_equality_enrichment(node, constraints)
+
+
+def test_dynamic_quantum_equality_requires_qubit_inputs(engine: AsyncEngine) -> None:
+    node = OperatorNode(id="eq_1", type="operator", operator="==")
+    constraints = Constraints(
+        requested_inputs={
+            0: QubitType(size=SINGLE_QUBIT_SIZE),
+            1: FloatType(size=32),
+        },
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+
+    with pytest.raises(InputTypeMismatch):
+        strategy._generate_equality_enrichment(node, constraints)
+
+
+def test_dynamic_quantum_equality_rejects_multi_qubit_registers(
+    engine: AsyncEngine,
+) -> None:
+    node = OperatorNode(id="eq_1", type="operator", operator="==")
+    constraints = Constraints(
+        requested_inputs={
+            0: QubitType(size=INVALID_REGISTER_SIZE),
+            1: QubitType(size=SINGLE_QUBIT_SIZE),
+        },
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+
+    with pytest.raises(InputSizeMismatch):
+        strategy._generate_equality_enrichment(node, constraints)


### PR DESCRIPTION
This PR adds dynamic backend support for the first Quantum Comparison Operator.

Implemented operator:
- `==`

Behavior:
- accepts two single-qubit inputs
- creates one result qubit
- initializes the result qubit to 1
- applies `cx lhs, result` and `cx rhs, result`
- result is 1 if both inputs are equal and 0 otherwise

For now, this implementation is intentionally limited to single-qubit equality. 

This is intended as the first small dynamic implementation for the Quantum Comparison Operator task.







# Definition of Done

- [ ] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [ ] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [ ] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [ ] **Deployment Readiness**: The work is ready for deployment to production if needed.
