### PR TITLE
Add measurement basis support

### DIFF
--- a/app/enricher/measure.py
+++ b/app/enricher/measure.py
@@ -11,6 +11,7 @@ from openqasm3.ast import (
     DiscreteSet,
     Expression,
     Identifier,
+    Include,
     IndexedIdentifier,
     IntegerLiteral,
     QuantumGate,
@@ -29,15 +30,13 @@ from app.enricher.exceptions import (
     InvalidSingleQubitIndex,
 )
 from app.enricher.utils import implementation, leqo_input, leqo_output
-from app.model.CompileRequest import (
-    MeasurementNode,
-)
-from app.model.CompileRequest import (
-    Node as FrontendNode,
-)
+from app.model.CompileRequest import MeasurementNode
+from app.model.CompileRequest import Node as FrontendNode
 from app.model.data_types import QubitType
 from app.model.exceptions import InputCountMismatch, InputTypeMismatch
 from app.utils import duplicates
+
+PAULI_BASES = frozenset({"I", "X", "Y", "Z"})
 
 
 def _quantum_gate(name: str, target: Identifier | IndexedIdentifier) -> QuantumGate:
@@ -47,6 +46,10 @@ def _quantum_gate(name: str, target: Identifier | IndexedIdentifier) -> QuantumG
         arguments=[],
         qubits=[target],
     )
+
+
+def _indexed_target(index: int) -> IndexedIdentifier:
+    return IndexedIdentifier(Identifier("q"), [[IntegerLiteral(index)]])
 
 
 def _basis_change_gates(
@@ -61,7 +64,48 @@ def _basis_change_gates(
             _quantum_gate("h", target),
         ]
 
-    return []
+    if basis in {"Z", "I"}:
+        return []
+
+    raise ValueError(f"Unsupported measurement basis '{basis}'.")
+
+
+def _stdgates_include_if_needed(
+    basis_change_gates: list[QuantumGate],
+) -> list[Include]:
+    if not basis_change_gates:
+        return []
+
+    return [Include("stdgates.inc")]
+
+
+def _resolve_basis_string(basis: str, output_size: int) -> list[str]:
+    normalized = basis.strip().upper()
+
+    if not normalized or any(char not in PAULI_BASES for char in normalized):
+        raise ValueError(f"Unsupported measurement basis '{basis}'.")
+
+    if len(normalized) == 1:
+        return [normalized] * output_size
+
+    if len(normalized) == output_size:
+        return list(normalized)
+
+    raise ValueError(
+        "Composite measurement basis length must either be 1 or match the "
+        f"number of measured qubits. Got basis '{basis}' for {output_size} qubits."
+    )
+
+
+def _basis_change_gates_for_indices(
+    bases: list[str], indices: list[int]
+) -> list[QuantumGate]:
+    gates: list[QuantumGate] = []
+
+    for basis, index in zip(bases, indices, strict=True):
+        gates.extend(_basis_change_gates(basis, _indexed_target(index)))
+
+    return gates
 
 
 class MeasurementEnricherStrategy(EnricherStrategy):
@@ -95,17 +139,53 @@ class MeasurementEnricherStrategy(EnricherStrategy):
         requested_type = constraints.requested_inputs[0]
         input_size = requested_type.size
         is_signed = getattr(requested_type, "signed", False)
-        basis = node.basis
+        basis_specs = node.pauliStrings or [node.basis]
 
         if input_size is None:
-            if node.indices not in ([], [0]):
-                raise InvalidSingleQubitIndex(node)
+            return self._enrich_single_qubit_measurement(
+                node=node,
+                is_signed=is_signed,
+                basis_specs=basis_specs,
+            )
 
+        indices = node.indices if len(node.indices) > 0 else list(range(input_size))
+
+        out_of_range_indices = [i for i in indices if i < 0 or i >= input_size]
+        if any(out_of_range_indices):
+            raise IndicesOutOfRange(node, out_of_range_indices, input_size)
+
+        duplicate_indices = list(duplicates(indices))
+        if len(duplicate_indices) != 0:
+            raise DuplicateIndices(node, duplicate_indices)
+
+        return self._enrich_multi_qubit_measurement(
+            node=node,
+            input_size=input_size,
+            is_signed=is_signed,
+            indices=indices,
+            basis_specs=basis_specs,
+        )
+
+    def _enrich_single_qubit_measurement(
+        self,
+        node: MeasurementNode,
+        is_signed: bool,
+        basis_specs: list[str],
+    ) -> EnrichmentResult | list[EnrichmentResult]:
+        if node.indices not in ([], [0]):
+            raise InvalidSingleQubitIndex(node)
+
+        results: list[EnrichmentResult] = []
+
+        for basis_spec in basis_specs:
+            bases = _resolve_basis_string(basis_spec, 1)
             measurement_target = Identifier("q")
-            basis_change_gates = _basis_change_gates(basis, measurement_target)
+            basis_change_gates = _basis_change_gates(bases[0], measurement_target)
+            stdgates_include = _stdgates_include_if_needed(basis_change_gates)
 
             statements = [
-                leqo_input("q", 0, input_size, twos_complement=is_signed),
+                *stdgates_include,
+                leqo_input("q", 0, None, twos_complement=is_signed),
                 *basis_change_gates,
                 ClassicalDeclaration(
                     BitType(),
@@ -127,51 +207,63 @@ class MeasurementEnricherStrategy(EnricherStrategy):
                 ]
             )
 
-            return EnrichmentResult(
-                implementation(
-                    node,
-                    statements,
-                ),
-                ImplementationMetaData(width=0, depth=1 + len(basis_change_gates)),
+            results.append(
+                EnrichmentResult(
+                    implementation(node, statements),
+                    ImplementationMetaData(width=0, depth=1 + len(basis_change_gates)),
+                )
             )
 
-        indices = node.indices if len(node.indices) > 0 else list(range(input_size))
+        return results[0] if len(results) == 1 else results
 
-        out_of_range_indices = [i for i in indices if i < 0 or i >= input_size]
-        if any(out_of_range_indices):
-            raise IndicesOutOfRange(node, out_of_range_indices, input_size)
-
-        duplicate_indices = list(duplicates(indices))
-        if len(duplicate_indices) != 0:
-            raise DuplicateIndices(node, duplicate_indices)
-
+    def _enrich_multi_qubit_measurement(
+        self,
+        node: MeasurementNode,
+        input_size: int,
+        is_signed: bool,
+        indices: list[int],
+        basis_specs: list[str],
+    ) -> EnrichmentResult | list[EnrichmentResult]:
         index_exprs: list[Expression] = [IntegerLiteral(x) for x in indices]
         output_size = len(index_exprs)
 
-        qubit_decl = leqo_input("q", 0, input_size, twos_complement=is_signed)
-        qubit_alias = leqo_output("qubit_out", 1, Identifier("q"))
-        if is_signed:
-            qubit_alias.annotations.append(Annotation("leqo.twos_complement", "true"))
+        results: list[EnrichmentResult] = []
 
-        measurement_target = IndexedIdentifier(
-            Identifier("q"), [DiscreteSet(index_exprs)]
-        )
-        basis_change_gates = _basis_change_gates(basis, measurement_target)
+        for basis_spec in basis_specs:
+            bases = _resolve_basis_string(basis_spec, output_size)
+            basis_change_gates = _basis_change_gates_for_indices(bases, indices)
+            stdgates_include = _stdgates_include_if_needed(basis_change_gates)
 
-        return EnrichmentResult(
-            implementation(
-                node,
-                [
-                    qubit_decl,
-                    *basis_change_gates,
-                    ClassicalDeclaration(
-                        BitType(IntegerLiteral(output_size)),
-                        Identifier("result"),
-                        QuantumMeasurement(measurement_target),
+            qubit_decl = leqo_input("q", 0, input_size, twos_complement=is_signed)
+            qubit_alias = leqo_output("qubit_out", 1, Identifier("q"))
+            if is_signed:
+                qubit_alias.annotations.append(
+                    Annotation("leqo.twos_complement", "true")
+                )
+
+            measurement_target = IndexedIdentifier(
+                Identifier("q"), [DiscreteSet(index_exprs)]
+            )
+
+            results.append(
+                EnrichmentResult(
+                    implementation(
+                        node,
+                        [
+                            *stdgates_include,
+                            qubit_decl,
+                            *basis_change_gates,
+                            ClassicalDeclaration(
+                                BitType(IntegerLiteral(output_size)),
+                                Identifier("result"),
+                                QuantumMeasurement(measurement_target),
+                            ),
+                            leqo_output("out", 0, Identifier("result")),
+                            qubit_alias,
+                        ],
                     ),
-                    leqo_output("out", 0, Identifier("result")),
-                    qubit_alias,
-                ],
-            ),
-            ImplementationMetaData(width=0, depth=1 + len(basis_change_gates)),
-        )
+                    ImplementationMetaData(width=0, depth=1 + len(basis_change_gates)),
+                )
+            )
+
+        return results[0] if len(results) == 1 else results

--- a/app/enricher/measure.py
+++ b/app/enricher/measure.py
@@ -13,6 +13,7 @@ from openqasm3.ast import (
     Identifier,
     IndexedIdentifier,
     IntegerLiteral,
+    QuantumGate,
     QuantumMeasurement,
 )
 
@@ -37,6 +38,30 @@ from app.model.CompileRequest import (
 from app.model.data_types import QubitType
 from app.model.exceptions import InputCountMismatch, InputTypeMismatch
 from app.utils import duplicates
+
+
+def _quantum_gate(name: str, target: Identifier | IndexedIdentifier) -> QuantumGate:
+    return QuantumGate(
+        modifiers=[],
+        name=Identifier(name),
+        arguments=[],
+        qubits=[target],
+    )
+
+
+def _basis_change_gates(
+    basis: str, target: Identifier | IndexedIdentifier
+) -> list[QuantumGate]:
+    if basis == "X":
+        return [_quantum_gate("h", target)]
+
+    if basis == "Y":
+        return [
+            _quantum_gate("sdg", target),
+            _quantum_gate("h", target),
+        ]
+
+    return []
 
 
 class MeasurementEnricherStrategy(EnricherStrategy):
@@ -70,35 +95,46 @@ class MeasurementEnricherStrategy(EnricherStrategy):
         requested_type = constraints.requested_inputs[0]
         input_size = requested_type.size
         is_signed = getattr(requested_type, "signed", False)
+        basis = node.basis
+
         if input_size is None:
             if node.indices not in ([], [0]):
                 raise InvalidSingleQubitIndex(node)
+
+            measurement_target = Identifier("q")
+            basis_change_gates = _basis_change_gates(basis, measurement_target)
+
             statements = [
                 leqo_input("q", 0, input_size, twos_complement=is_signed),
+                *basis_change_gates,
                 ClassicalDeclaration(
                     BitType(),
                     Identifier("result"),
-                    QuantumMeasurement(Identifier("q")),
+                    QuantumMeasurement(measurement_target),
                 ),
             ]
+
             qubit_alias = leqo_output("qubit_out", 1, Identifier("q"))
             if is_signed:
                 qubit_alias.annotations.append(
                     Annotation("leqo.twos_complement", "true")
                 )
+
             statements.extend(
                 [
                     leqo_output("out", 0, Identifier("result")),
                     qubit_alias,
                 ]
             )
+
             return EnrichmentResult(
                 implementation(
                     node,
                     statements,
                 ),
-                ImplementationMetaData(width=0, depth=1),
+                ImplementationMetaData(width=0, depth=1 + len(basis_change_gates)),
             )
+
         indices = node.indices if len(node.indices) > 0 else list(range(input_size))
 
         out_of_range_indices = [i for i in indices if i < 0 or i >= input_size]
@@ -117,23 +153,25 @@ class MeasurementEnricherStrategy(EnricherStrategy):
         if is_signed:
             qubit_alias.annotations.append(Annotation("leqo.twos_complement", "true"))
 
+        measurement_target = IndexedIdentifier(
+            Identifier("q"), [DiscreteSet(index_exprs)]
+        )
+        basis_change_gates = _basis_change_gates(basis, measurement_target)
+
         return EnrichmentResult(
             implementation(
                 node,
                 [
                     qubit_decl,
+                    *basis_change_gates,
                     ClassicalDeclaration(
                         BitType(IntegerLiteral(output_size)),
                         Identifier("result"),
-                        QuantumMeasurement(
-                            IndexedIdentifier(
-                                Identifier("q"), [DiscreteSet(index_exprs)]
-                            )
-                        ),
+                        QuantumMeasurement(measurement_target),
                     ),
                     leqo_output("out", 0, Identifier("result")),
                     qubit_alias,
                 ],
             ),
-            ImplementationMetaData(width=0, depth=1),
+            ImplementationMetaData(width=0, depth=1 + len(basis_change_gates)),
         )

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -204,8 +204,11 @@ class MeasurementNode(BaseNode):
     indices: list[Annotated[int, Field(ge=0)]]
     """List of qubit indices to measure."""
 
-    basis: Literal["X", "Y", "Z"] = "Z"
-    """Measurement basis. Defaults to Z-basis."""
+    basis: str = "Z"
+    """Measurement basis or composite Pauli basis string. Defaults to Z-basis."""
+
+    pauliStrings: list[str] = Field(default_factory=list)
+    """Optional list of Pauli strings to measure in one measurement node."""
 
     model_config = ConfigDict(use_attribute_docstrings=True)
 
@@ -248,6 +251,27 @@ class MeasurementNode(BaseNode):
         if basis is not None:
             normalized["basis"] = basis
 
+        pauli_strings = cls._parse_pauli_strings(normalized.get("pauliStrings"))
+        if pauli_strings is None:
+            pauli_strings = cls._parse_pauli_strings(normalized.get("pauli_strings"))
+
+        if pauli_strings is None and node_dict is not None:
+            pauli_strings = cls._parse_pauli_strings(
+                cls._first_existing_value(
+                    node_dict,
+                    (
+                        "pauliStrings",
+                        "pauli_strings",
+                        "pauliString",
+                        "pauli_string",
+                        "measurementPauliStrings",
+                    ),
+                )
+            )
+
+        if pauli_strings is not None:
+            normalized["pauliStrings"] = pauli_strings
+
         return normalized
 
     @staticmethod
@@ -265,16 +289,51 @@ class MeasurementNode(BaseNode):
             return None
 
         normalized = value.strip().upper()
+        alias = normalized.replace("_", " ").replace("-", " ")
 
-        match normalized:
-            case "X" | "X-BASIS" | "X BASIS":
+        match alias:
+            case "X BASIS":
                 return "X"
-            case "Y" | "Y-BASIS" | "Y BASIS":
+            case "Y BASIS":
                 return "Y"
-            case "Z" | "Z-BASIS" | "Z BASIS":
+            case "Z BASIS":
                 return "Z"
-            case _:
-                return None
+
+        compact = normalized.replace(" ", "")
+        if compact and all(char in {"I", "X", "Y", "Z"} for char in compact):
+            return compact
+
+        return None
+
+    @classmethod
+    def _parse_pauli_strings(cls, value: Any) -> list[str] | None:
+        if isinstance(value, list):
+            strings: list[str] = []
+            for item in value:
+                parsed = cls._parse_basis(item)
+                if parsed is None:
+                    return None
+                strings.append(parsed)
+
+            return strings or None
+
+        if isinstance(value, str):
+            parts = [
+                part.strip()
+                for part in value.replace(";", ",").split(",")
+                if part.strip()
+            ]
+
+            strings: list[str] = []
+            for part in parts:
+                parsed = cls._parse_basis(part)
+                if parsed is None:
+                    return None
+                strings.append(parsed)
+
+            return strings or None
+
+        return None
 
     @staticmethod
     def _coerce_indices(values: Iterable[Any]) -> list[int]:

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -204,6 +204,9 @@ class MeasurementNode(BaseNode):
     indices: list[Annotated[int, Field(ge=0)]]
     """List of qubit indices to measure."""
 
+    basis: Literal["X", "Y", "Z"] = "Z"
+    """Measurement basis. Defaults to Z-basis."""
+
     model_config = ConfigDict(use_attribute_docstrings=True)
 
     @model_validator(mode="before")
@@ -228,7 +231,50 @@ class MeasurementNode(BaseNode):
         if indices is not None:
             normalized["indices"] = indices
 
+        basis = cls._parse_basis(normalized.get("basis"))
+        if basis is None and node_dict is not None:
+            basis = cls._parse_basis(
+                cls._first_existing_value(
+                    node_dict,
+                    (
+                        "basis",
+                        "measurementBasis",
+                        "basisType",
+                        "measurementBasisType",
+                    ),
+                )
+            )
+
+        if basis is not None:
+            normalized["basis"] = basis
+
         return normalized
+
+    @staticmethod
+    def _first_existing_value(data: dict[str, Any], keys: tuple[str, ...]) -> Any:
+        for key in keys:
+            value = data.get(key)
+            if value is not None:
+                return value
+
+        return None
+
+    @staticmethod
+    def _parse_basis(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+
+        normalized = value.strip().upper()
+
+        match normalized:
+            case "X" | "X-BASIS" | "X BASIS":
+                return "X"
+            case "Y" | "Y-BASIS" | "Y BASIS":
+                return "Y"
+            case "Z" | "Z-BASIS" | "Z BASIS":
+                return "Z"
+            case _:
+                return None
 
     @staticmethod
     def _coerce_indices(values: Iterable[Any]) -> list[int]:

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -308,14 +308,14 @@ class MeasurementNode(BaseNode):
     @classmethod
     def _parse_pauli_strings(cls, value: Any) -> list[str] | None:
         if isinstance(value, list):
-            strings: list[str] = []
+            parsed_strings: list[str] = []
             for item in value:
                 parsed = cls._parse_basis(item)
                 if parsed is None:
                     return None
-                strings.append(parsed)
+                parsed_strings.append(parsed)
 
-            return strings or None
+            return parsed_strings or None
 
         if isinstance(value, str):
             parts = [
@@ -324,14 +324,14 @@ class MeasurementNode(BaseNode):
                 if part.strip()
             ]
 
-            strings: list[str] = []
+            parsed_parts: list[str] = []
             for part in parts:
                 parsed = cls._parse_basis(part)
                 if parsed is None:
                     return None
-                strings.append(parsed)
+                parsed_parts.append(parsed)
 
-            return strings or None
+            return parsed_parts or None
 
         return None
 

--- a/tests/enricher/test_measure.py
+++ b/tests/enricher/test_measure.py
@@ -247,6 +247,7 @@ async def test_measure_x_basis_single_qubit() -> None:
         "nodeId",
         """\
         OPENQASM 3.1;
+        include "stdgates.inc";
         @leqo.input 0
         qubit q;
         h q;
@@ -275,6 +276,7 @@ async def test_measure_y_basis_single_qubit() -> None:
         "nodeId",
         """\
         OPENQASM 3.1;
+        include "stdgates.inc";
         @leqo.input 0
         qubit q;
         sdg q;
@@ -304,9 +306,12 @@ async def test_measure_x_basis_multi_qubit_indices() -> None:
         "nodeId",
         """\
         OPENQASM 3.1;
+        include "stdgates.inc";
         @leqo.input 0
         qubit[3] q;
-        h q[{0, 1, 2}];
+        h q[0];
+        h q[1];
+        h q[2];
         bit[3] result = measure q[{0, 1, 2}];
         @leqo.output 0
         let out = result;
@@ -314,3 +319,103 @@ async def test_measure_x_basis_multi_qubit_indices() -> None:
         let qubit_out = q;
         """,
     )
+
+
+@pytest.mark.asyncio
+async def test_measure_composite_basis_multi_qubit_indices() -> None:
+    node = MeasurementNode(id="nodeId", indices=[0, 1, 2], basis="XYZ")
+    constraints = Constraints(
+        requested_inputs={0: QubitType(3)}, optimizeWidth=False, optimizeDepth=False
+    )
+
+    strategy = MeasurementEnricherStrategy()
+    result = list(await strategy.enrich(node, constraints))
+
+    assert len(result) == 1
+    assert_enrichment(
+        result[0].enriched_node,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        include "stdgates.inc";
+        @leqo.input 0
+        qubit[3] q;
+        h q[0];
+        sdg q[1];
+        h q[1];
+        bit[3] result = measure q[{0, 1, 2}];
+        @leqo.output 0
+        let out = result;
+        @leqo.output 1
+        let qubit_out = q;
+        """,
+    )
+
+
+@pytest.mark.asyncio
+async def test_measure_multiple_pauli_strings() -> None:
+    node = MeasurementNode(
+        id="nodeId",
+        indices=[0, 1],
+        pauliStrings=["XX", "YZ"],
+    )
+    constraints = Constraints(
+        requested_inputs={0: QubitType(2)}, optimizeWidth=False, optimizeDepth=False
+    )
+
+    strategy = MeasurementEnricherStrategy()
+    result = list(await strategy.enrich(node, constraints))
+
+    expected_result_count = 2
+    assert len(result) == expected_result_count
+
+    assert_enrichment(
+        result[0].enriched_node,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        include "stdgates.inc";
+        @leqo.input 0
+        qubit[2] q;
+        h q[0];
+        h q[1];
+        bit[2] result = measure q[{0, 1}];
+        @leqo.output 0
+        let out = result;
+        @leqo.output 1
+        let qubit_out = q;
+        """,
+    )
+
+    assert_enrichment(
+        result[1].enriched_node,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        include "stdgates.inc";
+        @leqo.input 0
+        qubit[2] q;
+        sdg q[0];
+        h q[0];
+        bit[2] result = measure q[{0, 1}];
+        @leqo.output 0
+        let out = result;
+        @leqo.output 1
+        let qubit_out = q;
+        """,
+    )
+
+
+@pytest.mark.asyncio
+async def test_measure_composite_basis_length_mismatch() -> None:
+    node = MeasurementNode(id="nodeId", indices=[0, 1, 2], basis="XY")
+    constraints = Constraints(
+        requested_inputs={0: QubitType(3)}, optimizeWidth=False, optimizeDepth=False
+    )
+
+    strategy = MeasurementEnricherStrategy()
+    with pytest.raises(
+        ValueError,
+        match="Composite measurement basis length must either be 1 or match",
+    ):
+        await strategy.enrich(node, constraints)

--- a/tests/enricher/test_measure.py
+++ b/tests/enricher/test_measure.py
@@ -229,3 +229,88 @@ async def test_duplicate_indices() -> None:
     strategy = MeasurementEnricherStrategy()
     with pytest.raises(DuplicateIndices, match=r"^Duplicate indices \[1, 2\]$"):
         await strategy.enrich(node, constraints)
+
+
+@pytest.mark.asyncio
+async def test_measure_x_basis_single_qubit() -> None:
+    node = MeasurementNode(id="nodeId", indices=[0], basis="X")
+    constraints = Constraints(
+        requested_inputs={0: QubitType(None)}, optimizeWidth=False, optimizeDepth=False
+    )
+
+    strategy = MeasurementEnricherStrategy()
+    result = list(await strategy.enrich(node, constraints))
+
+    assert len(result) == 1
+    assert_enrichment(
+        result[0].enriched_node,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        @leqo.input 0
+        qubit q;
+        h q;
+        bit result = measure q;
+        @leqo.output 0
+        let out = result;
+        @leqo.output 1
+        let qubit_out = q;
+        """,
+    )
+
+
+@pytest.mark.asyncio
+async def test_measure_y_basis_single_qubit() -> None:
+    node = MeasurementNode(id="nodeId", indices=[0], basis="Y")
+    constraints = Constraints(
+        requested_inputs={0: QubitType(None)}, optimizeWidth=False, optimizeDepth=False
+    )
+
+    strategy = MeasurementEnricherStrategy()
+    result = list(await strategy.enrich(node, constraints))
+
+    assert len(result) == 1
+    assert_enrichment(
+        result[0].enriched_node,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        @leqo.input 0
+        qubit q;
+        sdg q;
+        h q;
+        bit result = measure q;
+        @leqo.output 0
+        let out = result;
+        @leqo.output 1
+        let qubit_out = q;
+        """,
+    )
+
+
+@pytest.mark.asyncio
+async def test_measure_x_basis_multi_qubit_indices() -> None:
+    node = MeasurementNode(id="nodeId", indices=[0, 1, 2], basis="X")
+    constraints = Constraints(
+        requested_inputs={0: QubitType(3)}, optimizeWidth=False, optimizeDepth=False
+    )
+
+    strategy = MeasurementEnricherStrategy()
+    result = list(await strategy.enrich(node, constraints))
+
+    assert len(result) == 1
+    assert_enrichment(
+        result[0].enriched_node,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        @leqo.input 0
+        qubit[3] q;
+        h q[{0, 1, 2}];
+        bit[3] result = measure q[{0, 1, 2}];
+        @leqo.output 0
+        let out = result;
+        @leqo.output 1
+        let qubit_out = q;
+        """,
+    )


### PR DESCRIPTION
This PR extends the measurement node with support for X, Y, and Z measurement bases.

Z remains the default behavior and keeps the existing direct OpenQASM measurement.
X-basis measurement is implemented by adding an H gate before measurement.
Y-basis measurement is implemented by adding Sdg followed by H before measurement.

Additional tests cover X-basis and Y-basis measurements for single-qubit and multi-qubit cases.




# Definition of Done

- [ ] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [ ] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [ ] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [ ] **Deployment Readiness**: The work is ready for deployment to production if needed.
