### PR TITLE
Feature/controlled u

### DIFF
--- a/app/enricher/gates.py
+++ b/app/enricher/gates.py
@@ -6,7 +6,16 @@ Provides enricher strategy for gate nodes
 
 from typing import get_args, override
 
-from openqasm3.ast import Expression, FloatLiteral, Identifier, Include, QuantumGate
+from openqasm3.ast import (
+    Expression,
+    FloatLiteral,
+    GateModifierName,
+    Identifier,
+    Include,
+    IntegerLiteral,
+    QuantumGate,
+    QuantumGateModifier,
+)
 
 from app.enricher import (
     Constraints,
@@ -84,6 +93,26 @@ def _validate_constraints(
     return size
 
 
+def _control_modifiers(control_count: int) -> list[QuantumGateModifier]:
+    if control_count == 0:
+        return []
+
+    if control_count == 1:
+        return [
+            QuantumGateModifier(
+                modifier=GateModifierName.ctrl,
+                argument=None,
+            )
+        ]
+
+    return [
+        QuantumGateModifier(
+            modifier=GateModifierName.ctrl,
+            argument=IntegerLiteral(control_count),
+        )
+    ]
+
+
 def enrich_gate(
     node: Node,
     constraints: Constraints | None,
@@ -97,29 +126,31 @@ def enrich_gate(
     :param node: Node that defined the gate. (Used as context for errors etc.)
     :param constraints: Constraints that should be applied.
     :param gate_name: Name of the gate to generate.
-    :param input_count: Count of expected inputs.
+    :param input_count: Count of expected target inputs for the base gate.
     :param arguments: Optional arguments passed to the gate.
     :return: Final enrichment result.
     """
 
-    size = _validate_constraints(constraints, node, input_count)
+    control_count = getattr(node, "controlCount", 0)
+    total_input_count = input_count + control_count
+    size = _validate_constraints(constraints, node, total_input_count)
 
     return EnrichmentResult(
         implementation(
             node,
             [
                 Include("stdgates.inc"),
-                *(leqo_input(f"q{i}", i, size) for i in range(input_count)),
+                *(leqo_input(f"q{i}", i, size) for i in range(total_input_count)),
                 QuantumGate(
-                    modifiers=[],
+                    modifiers=_control_modifiers(control_count),
                     name=Identifier(gate_name),
                     arguments=list(arguments),
-                    qubits=[Identifier(f"q{i}") for i in range(input_count)],
+                    qubits=[Identifier(f"q{i}") for i in range(total_input_count)],
                     duration=None,
                 ),
                 *(
                     leqo_output(f"q{i}_out", i, Identifier(f"q{i}"))
-                    for i in range(input_count)
+                    for i in range(total_input_count)
                 ),
             ],
         ),

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -304,6 +304,9 @@ class GateNode(BaseNode):
     gate: OneQubitGate | TwoQubitGate | ThreeQubitGate | Literal["cnot", "toffoli"]
     """The gate to apply (e.g., "x", "cnot", etc.)."""
 
+    controlCount: int = Field(default=0, ge=0)
+    """Number of control qubits used for controlled gate application."""
+
     model_config = ConfigDict(use_attribute_docstrings=True)
 
 
@@ -319,6 +322,9 @@ class ParameterizedGateNode(BaseNode):
 
     parameter: float
     """Value of the gate's parameter."""
+
+    controlCount: int = Field(default=0, ge=0)
+    """Number of control qubits used for controlled gate application."""
 
     model_config = ConfigDict(use_attribute_docstrings=True)
 

--- a/tests/enricher/test_gates.py
+++ b/tests/enricher/test_gates.py
@@ -230,3 +230,103 @@ def test_supported_controlled_rotation_lcm_gates_are_mapped_to_qasm(
         let q1_out = q1;
         """,
     )
+
+
+def test_controlled_single_qubit_gate_is_mapped_to_qasm() -> None:
+    node = GateNode(id="nodeId", gate="x", controlCount=1)
+    constraints = Constraints(
+        requested_inputs={0: QubitType(3), 1: QubitType(3)},
+        optimizeWidth=False,
+        optimizeDepth=False,
+    )
+
+    result = GateEnricherStrategy()._enrich_simple_gate(node, constraints).enriched_node
+
+    assert_enrichment(
+        result,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        include "stdgates.inc";
+        @leqo.input 0
+        qubit[3] q0;
+        @leqo.input 1
+        qubit[3] q1;
+        ctrl @ x q0, q1;
+        @leqo.output 0
+        let q0_out = q0;
+        @leqo.output 1
+        let q1_out = q1;
+        """,
+    )
+
+
+def test_multi_controlled_single_qubit_gate_is_mapped_to_qasm() -> None:
+    node = GateNode(id="nodeId", gate="x", controlCount=2)
+    constraints = Constraints(
+        requested_inputs={0: QubitType(3), 1: QubitType(3), 2: QubitType(3)},
+        optimizeWidth=False,
+        optimizeDepth=False,
+    )
+
+    result = GateEnricherStrategy()._enrich_simple_gate(node, constraints).enriched_node
+
+    assert_enrichment(
+        result,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        include "stdgates.inc";
+        @leqo.input 0
+        qubit[3] q0;
+        @leqo.input 1
+        qubit[3] q1;
+        @leqo.input 2
+        qubit[3] q2;
+        ctrl(2) @ x q0, q1, q2;
+        @leqo.output 0
+        let q0_out = q0;
+        @leqo.output 1
+        let q1_out = q1;
+        @leqo.output 2
+        let q2_out = q2;
+        """,
+    )
+
+
+def test_controlled_parameterized_gate_is_mapped_to_qasm() -> None:
+    node = ParameterizedGateNode(
+        id="nodeId",
+        gate="rx",
+        parameter=0.5,
+        controlCount=1,
+    )
+    constraints = Constraints(
+        requested_inputs={0: QubitType(3), 1: QubitType(3)},
+        optimizeWidth=False,
+        optimizeDepth=False,
+    )
+
+    result = (
+        GateEnricherStrategy()
+        ._enrich_parameterized_gate(node, constraints)
+        .enriched_node
+    )
+
+    assert_enrichment(
+        result,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        include "stdgates.inc";
+        @leqo.input 0
+        qubit[3] q0;
+        @leqo.input 1
+        qubit[3] q1;
+        ctrl @ rx(0.5) q0, q1;
+        @leqo.output 0
+        let q0_out = q0;
+        @leqo.output 1
+        let q1_out = q1;
+        """,
+    )


### PR DESCRIPTION
This PR adds Controlled-U style support for existing regular and parameterized gate nodes.

Here, U refers to an already supported gate operation, such as x, h, rx, ry, or rz. A new controlCount property is added to GateNode and ParameterizedGateNode. The gate enricher uses this value to emit OpenQASM 3 ctrl modifiers:

- controlCount = 0 keeps the existing behavior
- controlCount = 1 emits ctrl @ U
- controlCount > 1 emits ctrl(n) @ U

For example, GateNode(gate="x", controlCount=1) is emitted as ctrl @ x, and ParameterizedGateNode(gate="rx", parameter=0.5, controlCount=1) is emitted as ctrl @ rx(0.5).

Additional tests cover single-control, multi-control, and controlled parameterized gates.




# Definition of Done

- [ ] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [ ] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [ ] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [ ] **Deployment Readiness**: The work is ready for deployment to production if needed.
