### PR TITLE
Add dynamic quantum subtraction operator

### DIFF
--- a/app/enricher/operator.py
+++ b/app/enricher/operator.py
@@ -150,6 +150,9 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
         elif node.operator == "+":
             result = await self._enrich_addition_operator(node, constraints)
 
+        elif node.operator == "-":
+            result = await self._enrich_subtraction_operator(node, constraints)
+
         elif node.operator == "min":
             result = await self._enrich_single_qubit_binary_operator(
                 node,
@@ -213,6 +216,51 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
             )
 
         return [self._generate_addition_enrichment(node, constraints)]
+
+    async def _enrich_subtraction_operator(
+        self,
+        node: OperatorNode,
+        constraints: Constraints | None,
+    ) -> list[EnrichmentResult]:
+        dynamic_exception: Exception | None = None
+
+        if constraints is not None:
+            try:
+                return [self._generate_subtraction_enrichment(node, constraints)]
+            except (InputCountMismatch, InputTypeMismatch):
+                raise
+            except Exception as exc:  # pragma: no cover - defensive fallback
+                dynamic_exception = exc
+
+        try:
+            db_results = await super()._enrich_impl(node, constraints)
+        except InputCountMismatch:
+            if constraints is not None:
+                raise
+            db_results = []
+
+        if db_results:
+            return db_results
+
+        fallback_results = await self._fetch_operator_without_size_constraints(
+            node,
+            constraints,
+        )
+        if fallback_results:
+            return fallback_results
+
+        if dynamic_exception is not None:
+            raise dynamic_exception
+
+        if constraints is None:
+            raise InputCountMismatch(
+                node,
+                actual=0,
+                should_be="equal",
+                expected=2,
+            )
+
+        return [self._generate_subtraction_enrichment(node, constraints)]
 
     async def _enrich_single_qubit_binary_operator(
         self,
@@ -289,6 +337,55 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
         enriched_node = implementation(node, statements)
         width = (
             addend0.effective_size + addend1.effective_size + result_size + carry_count
+        )
+        return EnrichmentResult(
+            enriched_node,
+            ImplementationMetaData(width=width, depth=depth),
+        )
+
+    def _generate_subtraction_enrichment(
+        self, node: OperatorNode, constraints: Constraints
+    ) -> EnrichmentResult:
+        requested_inputs = constraints.requested_inputs
+        self._check_constraints(node, requested_inputs)
+
+        lhs = cast(QubitType, requested_inputs[0])
+        rhs = cast(QubitType, requested_inputs[1])
+
+        minuend = _AdditionOperand(
+            name="minuend",
+            index=0,
+            declared_size=lhs.size,
+            effective_size=lhs.size or 1,
+            signed=lhs.signed,
+        )
+        subtrahend = _AdditionOperand(
+            name="subtrahend",
+            index=1,
+            declared_size=rhs.size,
+            effective_size=rhs.size or 1,
+            signed=rhs.signed,
+        )
+
+        (
+            statements,
+            result_size,
+            complement_count,
+            carry_count,
+            depth,
+        ) = self._build_subtraction_statements(
+            minuend=minuend,
+            subtrahend=subtrahend,
+        )
+
+        enriched_node = implementation(node, statements)
+        width = (
+            minuend.effective_size
+            + subtrahend.effective_size
+            + result_size
+            + complement_count
+            + carry_count
+            + 1
         )
         return EnrichmentResult(
             enriched_node,
@@ -706,6 +803,140 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
         statements.append(output_alias)
 
         return statements, result_size, carry_count, depth
+
+    def _build_subtraction_statements(
+        self,
+        *,
+        minuend: _AdditionOperand,
+        subtrahend: _AdditionOperand,
+    ) -> tuple[list[Statement], int, int, int, int]:
+        max_operand_bits = max(minuend.effective_size, subtrahend.effective_size)
+        iteration_bits = max_operand_bits + 1
+        result_size = iteration_bits
+        complement_count = iteration_bits
+        carry_count = max(iteration_bits - 1, 0)
+
+        statements: list[Statement] = [
+            Include("stdgates.inc"),
+            leqo_input(
+                minuend.name,
+                minuend.index,
+                minuend.declared_size,
+                twos_complement=minuend.signed,
+            ),
+            leqo_input(
+                subtrahend.name,
+                subtrahend.index,
+                subtrahend.declared_size,
+                twos_complement=subtrahend.signed,
+            ),
+            QubitDeclaration(
+                Identifier("difference"),
+                IntegerLiteral(result_size),
+            ),
+            QubitDeclaration(
+                Identifier("rhs_complement"),
+                IntegerLiteral(complement_count),
+            ),
+            QubitDeclaration(
+                Identifier("one"),
+                IntegerLiteral(1),
+            ),
+        ]
+
+        if carry_count > 0:
+            statements.append(
+                QubitDeclaration(
+                    Identifier("carry"),
+                    IntegerLiteral(carry_count),
+                )
+            )
+
+        minuend_bits = self._build_qubit_references(
+            minuend.name,
+            minuend.declared_size,
+            minuend.effective_size,
+        )
+        subtrahend_bits = self._build_qubit_references(
+            subtrahend.name,
+            subtrahend.declared_size,
+            subtrahend.effective_size,
+        )
+        result_bits = self._build_qubit_references(
+            "difference",
+            result_size,
+            result_size,
+        )
+        complement_bits = self._build_qubit_references(
+            "rhs_complement",
+            complement_count,
+            complement_count,
+        )
+        carry_bits = [
+            self._qubit_reference("carry", index) for index in range(carry_count)
+        ]
+        one_bit = self._qubit_reference("one", 0)
+
+        gate_statements: list[Statement] = []
+        depth = 0
+
+        gate_statements.append(
+            QuantumGate(
+                modifiers=[],
+                name=Identifier("x"),
+                arguments=[],
+                qubits=[one_bit],
+                duration=None,
+            )
+        )
+        depth += 1
+
+        for index in range(iteration_bits):
+            complement_bit = complement_bits[index]
+            subtrahend_bit = self._select_operand_bit(
+                subtrahend,
+                subtrahend_bits,
+                index,
+            )
+
+            gate_statements.append(
+                QuantumGate(
+                    modifiers=[],
+                    name=Identifier("x"),
+                    arguments=[],
+                    qubits=[complement_bit],
+                    duration=None,
+                )
+            )
+            depth += 1
+
+            if subtrahend_bit is not None:
+                gate_statements.append(self._cx_gate(subtrahend_bit, complement_bit))
+                depth += 1
+
+        for index in range(iteration_bits):
+            minuend_bit = self._select_operand_bit(minuend, minuend_bits, index)
+            complement_bit = complement_bits[index]
+            result_bit = result_bits[index]
+            carry_in = one_bit if index == 0 else carry_bits[index - 1]
+            carry_out = carry_bits[index] if index < carry_count else None
+
+            round_statements, round_depth = self._build_addition_round(
+                addend0_bit=minuend_bit,
+                addend1_bit=complement_bit,
+                result_bit=result_bit,
+                carry_in=carry_in,
+                carry_out=carry_out,
+            )
+            gate_statements.extend(round_statements)
+            depth += round_depth
+
+        statements.extend(gate_statements)
+        output_alias = leqo_output("out", 0, Identifier("difference"))
+        output_alias.annotations.append(Annotation("leqo.twos_complement", "true"))
+        statements.append(output_alias)
+
+        return statements, result_size, complement_count, carry_count, depth
 
     def _determine_carry_out(
         self,

--- a/tests/enricher/test_operator.py
+++ b/tests/enricher/test_operator.py
@@ -376,3 +376,110 @@ async def test_enrich_operator_node_not_in_db(engine: AsyncEngine) -> None:
     )
 
     assert (await OperatorEnricherStrategy(engine).enrich(node, constraints)) == []
+
+
+@pytest.mark.asyncio
+async def test_enrich_minus_operator(engine: AsyncEngine) -> None:
+    node = FrontendOperatorNode(id="1", label=None, type="operator", operator="-")
+    constraints = Constraints(
+        requested_inputs={0: QubitType(size=3), 1: QubitType(size=4)},
+        optimizeDepth=True,
+        optimizeWidth=True,
+    )
+
+    enrichment_results = await OperatorEnricherStrategy(engine).enrich(
+        node, constraints
+    )
+    enrichment_results = list(enrichment_results)
+
+    assert len(enrichment_results) == 1
+
+    result = enrichment_results[0]
+    lhs_size = constraints.requested_inputs[0].size or 1
+    rhs_size = constraints.requested_inputs[1].size or 1
+    max_bits = max(lhs_size, rhs_size)
+    expected_result_size = max_bits + 1
+    expected_complement = expected_result_size
+    expected_carry = max(expected_result_size - 1, 0)
+    expected_width = (
+        lhs_size
+        + rhs_size
+        + expected_result_size
+        + expected_complement
+        + expected_carry
+        + 1
+    )
+
+    assert result.meta_data.width == expected_width
+    assert result.meta_data.depth is not None
+    assert result.meta_data.depth > 0
+
+    program = result.enriched_node.implementation
+    assert isinstance(program, Program)
+
+    alias_statement = program.statements[-1]
+    assert isinstance(alias_statement, AliasStatement)
+    assert any(
+        annotation.keyword == "leqo.twos_complement"
+        for annotation in alias_statement.annotations
+    )
+
+    output_value = alias_statement.value
+    assert isinstance(output_value, Identifier)
+    assert output_value.name == "difference"
+
+
+@pytest.mark.asyncio
+async def test_subtraction_uses_twos_complement_construction(
+    engine: AsyncEngine,
+) -> None:
+    node = FrontendOperatorNode(id="1", label=None, type="operator", operator="-")
+    constraints = Constraints(
+        requested_inputs={0: QubitType(size=2), 1: QubitType(size=2)},
+        optimizeDepth=True,
+        optimizeWidth=True,
+    )
+
+    enrichment = OperatorEnricherStrategy(engine)._generate_subtraction_enrichment(
+        node, constraints
+    )
+
+    program = enrichment.enriched_node.implementation
+    assert isinstance(program, Program)
+
+    difference_decl = next(
+        stmt
+        for stmt in program.statements
+        if isinstance(stmt, QubitDeclaration) and stmt.qubit.name == "difference"
+    )
+    complement_decl = next(
+        stmt
+        for stmt in program.statements
+        if isinstance(stmt, QubitDeclaration) and stmt.qubit.name == "rhs_complement"
+    )
+    one_decl = next(
+        stmt
+        for stmt in program.statements
+        if isinstance(stmt, QubitDeclaration) and stmt.qubit.name == "one"
+    )
+
+    expected_subtraction_register_size = 3
+    min_twos_complement_x_gate_count = 4
+
+    assert difference_decl.size.value == expected_subtraction_register_size
+    assert complement_decl.size.value == expected_subtraction_register_size
+    assert one_decl.size.value == 1
+
+    x_gates = [
+        statement
+        for statement in program.statements
+        if isinstance(statement, QuantumGate) and statement.name.name == "x"
+    ]
+    cx_gates = [
+        statement
+        for statement in program.statements
+        if isinstance(statement, QuantumGate) and statement.name.name == "cx"
+    ]
+
+    assert len(x_gates) >= min_twos_complement_x_gate_count
+    assert len(cx_gates) > 0


### PR DESCRIPTION
This PR adds dynamic backend enrichment for the quantum subtraction operator.

The existing dynamic arithmetic path already supports `+`. This change extends it with `-` by generating a subtraction circuit based on two's-complement construction:

lhs - rhs = lhs + (~rhs + 1)

The subtraction result is exposed as a two's-complement encoded output, since subtraction may produce negative values.

Tests cover:
- dynamic enrichment for the `-` operator
- metadata width/depth calculation
- two's-complement construction registers
- generated gate structure for subtraction



# Definition of Done

- [ ] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [ ] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [ ] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [ ] **Deployment Readiness**: The work is ready for deployment to production if needed.
