### PR TITLE
Add multi-parameter CU gate support

### DIFF
--- a/app/enricher/gates.py
+++ b/app/enricher/gates.py
@@ -46,7 +46,11 @@ from app.openqasm3.stdgates import (
     TwoQubitGate,
     TwoQubitGateWithAngle,
     TwoQubitGateWithParam,
+    TwoQubitGateWithParams,
 )
+
+_CU_PARAMETER_COUNT = 4
+_SINGLE_PARAMETER_COUNT = 1
 
 
 def _validate_constraints(
@@ -111,6 +115,24 @@ def _control_modifiers(control_count: int) -> list[QuantumGateModifier]:
             argument=IntegerLiteral(control_count),
         )
     ]
+
+
+def _parameter_literals(
+    node: ParameterizedGateNode,
+    expected_parameter_count: int,
+) -> list[FloatLiteral]:
+    parameters = getattr(node, "parameters", None)
+
+    if parameters is None:
+        if node.parameter is None:
+            raise GateNotSupported(node)
+
+        parameters = [node.parameter]
+
+    if len(parameters) != expected_parameter_count:
+        raise GateNotSupported(node)
+
+    return [FloatLiteral(parameter) for parameter in parameters]
 
 
 def enrich_gate(
@@ -212,12 +234,20 @@ class GateEnricherStrategy(EnricherStrategy):
 
         if node.gate in get_args(OneQubitGateWithAngle):
             return enrich_gate(
-                node, constraints, node.gate, 1, FloatLiteral(node.parameter)
+                node,
+                constraints,
+                node.gate,
+                1,
+                *_parameter_literals(node, _SINGLE_PARAMETER_COUNT),
             )
 
         if node.gate in get_args(TwoQubitGateWithAngle):
             return enrich_gate(
-                node, constraints, node.gate, 2, FloatLiteral(node.parameter)
+                node,
+                constraints,
+                node.gate,
+                2,
+                *_parameter_literals(node, _SINGLE_PARAMETER_COUNT),
             )
 
         # Gates with generic params are currently handled exactly like gates with angles
@@ -225,7 +255,20 @@ class GateEnricherStrategy(EnricherStrategy):
 
         if node.gate in get_args(TwoQubitGateWithParam):
             return enrich_gate(
-                node, constraints, node.gate, 2, FloatLiteral(node.parameter)
+                node,
+                constraints,
+                node.gate,
+                2,
+                *_parameter_literals(node, _SINGLE_PARAMETER_COUNT),
+            )
+
+        if node.gate in get_args(TwoQubitGateWithParams):
+            return enrich_gate(
+                node,
+                constraints,
+                node.gate,
+                2,
+                *_parameter_literals(node, _CU_PARAMETER_COUNT),
             )
 
         raise GateNotSupported(node)

--- a/app/model/CompileRequest.py
+++ b/app/model/CompileRequest.py
@@ -20,6 +20,7 @@ from app.openqasm3.stdgates import (
     TwoQubitGate,
     TwoQubitGateWithAngle,
     TwoQubitGateWithParam,
+    TwoQubitGateWithParams,
 )
 
 
@@ -312,16 +313,24 @@ class GateNode(BaseNode):
 
 class ParameterizedGateNode(BaseNode):
     """
-    Node representing a gate that requires a parameter (e.g., angle rotation).
+    Node representing a gate that requires one or more parameters.
     """
 
     type: Literal["gate-with-param"] = "gate-with-param"
 
-    gate: OneQubitGateWithAngle | TwoQubitGateWithParam | TwoQubitGateWithAngle
+    gate: (
+        OneQubitGateWithAngle
+        | TwoQubitGateWithParam
+        | TwoQubitGateWithAngle
+        | TwoQubitGateWithParams
+    )
     """The parameterized gate to apply."""
 
-    parameter: float
-    """Value of the gate's parameter."""
+    parameter: float | None = None
+    """Single parameter value for one-parameter gates."""
+
+    parameters: list[float] | None = None
+    """Parameter values for multi-parameter gates such as cu."""
 
     controlCount: int = Field(default=0, ge=0)
     """Number of control qubits used for controlled gate application."""

--- a/app/openqasm3/stdgates.py
+++ b/app/openqasm3/stdgates.py
@@ -12,4 +12,5 @@ ThreeQubitGate = Literal["ccx", "cswap"]
 
 OneQubitGateWithAngle = Literal["rx", "ry", "rz", "p"]
 TwoQubitGateWithParam = Literal["cp"]
+TwoQubitGateWithParams = Literal["cu"]
 TwoQubitGateWithAngle = Literal["crx", "cry", "crz"]

--- a/tests/enricher/test_gates.py
+++ b/tests/enricher/test_gates.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.enricher import Constraints
+from app.enricher.exceptions import GateNotSupported
 from app.enricher.gates import GateEnricherStrategy, enrich_gate
 from app.model.CompileRequest import GateNode, ParameterizedGateNode
 from app.model.data_types import IntType, QubitType
@@ -330,3 +331,56 @@ def test_controlled_parameterized_gate_is_mapped_to_qasm() -> None:
         let q1_out = q1;
         """,
     )
+
+
+def test_supported_cu_gate_is_mapped_to_qasm() -> None:
+    node = ParameterizedGateNode(
+        id="nodeId",
+        gate="cu",
+        parameters=[0.1, 0.2, 0.3, 0.4],
+    )
+    constraints = Constraints(
+        requested_inputs={0: QubitType(3), 1: QubitType(3)},
+        optimizeWidth=False,
+        optimizeDepth=False,
+    )
+
+    result = (
+        GateEnricherStrategy()
+        ._enrich_parameterized_gate(node, constraints)
+        .enriched_node
+    )
+
+    assert_enrichment(
+        result,
+        "nodeId",
+        """\
+        OPENQASM 3.1;
+        include "stdgates.inc";
+        @leqo.input 0
+        qubit[3] q0;
+        @leqo.input 1
+        qubit[3] q1;
+        cu(0.1, 0.2, 0.3, 0.4) q0, q1;
+        @leqo.output 0
+        let q0_out = q0;
+        @leqo.output 1
+        let q1_out = q1;
+        """,
+    )
+
+
+def test_cu_gate_rejects_wrong_parameter_count() -> None:
+    node = ParameterizedGateNode(
+        id="nodeId",
+        gate="cu",
+        parameters=[0.1, 0.2, 0.3],
+    )
+    constraints = Constraints(
+        requested_inputs={0: QubitType(3), 1: QubitType(3)},
+        optimizeWidth=False,
+        optimizeDepth=False,
+    )
+
+    with pytest.raises(GateNotSupported):
+        GateEnricherStrategy()._enrich_parameterized_gate(node, constraints)


### PR DESCRIPTION
This PR adds support for the CU gate by allowing parameterized gate nodes to carry a list of parameters. The CU gate is mapped to OpenQASM as:

cu(theta, phi, lambda, gamma) q0, q1;

The existing single-parameter gate behavior is kept unchanged.

## Changes

- Added `TwoQubitGateWithParams = Literal["cu"]`
- Extended `ParameterizedGateNode` with optional `parameters: list[float]`
- Added CU handling in the gate enricher
- Added tests for valid CU QASM generation
- Added a test for invalid CU parameter count

# Definition of Done

- [ ] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [ ] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [ ] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [ ] **Deployment Readiness**: The work is ready for deployment to production if needed.
