### PR TITLE
Extend dynamic quantum comparison predicates

### DIFF
--- a/app/enricher/operator.py
+++ b/app/enricher/operator.py
@@ -129,11 +129,11 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
         if not isinstance(node, OperatorNode):
             result = await super()._enrich_impl(node, constraints)
 
-        elif node.operator == "==":
+        elif node.operator in {"==", "!=", "<", ">", "<=", ">="}:
             result = await self._enrich_single_qubit_binary_operator(
                 node,
                 constraints,
-                self._generate_equality_enrichment,
+                self._generate_comparison_enrichment,
             )
 
         elif node.operator == "~":
@@ -397,6 +397,13 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
         node: OperatorNode,
         constraints: Constraints,
     ) -> EnrichmentResult:
+        return self._generate_comparison_enrichment(node, constraints)
+
+    def _generate_comparison_enrichment(
+        self,
+        node: OperatorNode,
+        constraints: Constraints,
+    ) -> EnrichmentResult:
         requested_inputs = constraints.requested_inputs
         self._check_constraints(node, requested_inputs)
 
@@ -420,6 +427,13 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
         rhs_ref = self._build_qubit_references(rhs_name, rhs.size, rhs_size)[0]
         result_ref = Identifier(result_name)
 
+        comparison_gates = self._comparison_gates(
+            node.operator,
+            lhs_ref,
+            rhs_ref,
+            result_ref,
+        )
+
         statements: list[Statement] = [
             Include("stdgates.inc"),
             leqo_input(
@@ -438,21 +452,74 @@ class OperatorEnricherStrategy(DataBaseEnricherStrategy):
                 result_ref,
                 IntegerLiteral(1),
             ),
-            QuantumGate(
-                modifiers=[],
-                name=Identifier("x"),
-                arguments=[],
-                qubits=[result_ref],
-                duration=None,
-            ),
-            self._cx_gate(lhs_ref, result_ref),
-            self._cx_gate(rhs_ref, result_ref),
+            *comparison_gates,
             leqo_output("out", 0, result_ref),
         ]
 
         return EnrichmentResult(
             implementation(node, statements),
-            ImplementationMetaData(width=3, depth=3),
+            ImplementationMetaData(width=3, depth=len(comparison_gates)),
+        )
+
+    def _comparison_gates(
+        self,
+        operator: str,
+        lhs_ref: Identifier | IndexedIdentifier,
+        rhs_ref: Identifier | IndexedIdentifier,
+        result_ref: Identifier | IndexedIdentifier,
+    ) -> list[QuantumGate]:
+        if operator == "==":
+            return [
+                self._x_gate(result_ref),
+                self._cx_gate(lhs_ref, result_ref),
+                self._cx_gate(rhs_ref, result_ref),
+            ]
+
+        if operator == "!=":
+            return [
+                self._cx_gate(lhs_ref, result_ref),
+                self._cx_gate(rhs_ref, result_ref),
+            ]
+
+        if operator == "<":
+            return [
+                self._x_gate(lhs_ref),
+                self._ccx_gate(lhs_ref, rhs_ref, result_ref),
+                self._x_gate(lhs_ref),
+            ]
+
+        if operator == ">":
+            return [
+                self._x_gate(rhs_ref),
+                self._ccx_gate(lhs_ref, rhs_ref, result_ref),
+                self._x_gate(rhs_ref),
+            ]
+
+        if operator == "<=":
+            return [
+                self._x_gate(result_ref),
+                self._x_gate(rhs_ref),
+                self._ccx_gate(lhs_ref, rhs_ref, result_ref),
+                self._x_gate(rhs_ref),
+            ]
+
+        if operator == ">=":
+            return [
+                self._x_gate(result_ref),
+                self._x_gate(lhs_ref),
+                self._ccx_gate(lhs_ref, rhs_ref, result_ref),
+                self._x_gate(lhs_ref),
+            ]
+
+        raise ValueError(f"Unsupported comparison operator: {operator}")
+
+    def _x_gate(self, target: Identifier | IndexedIdentifier) -> QuantumGate:
+        return QuantumGate(
+            modifiers=[],
+            name=Identifier("x"),
+            arguments=[],
+            qubits=[target],
+            duration=None,
         )
 
     def _generate_bitwise_not_enrichment(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,10 +43,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
     "fastapi": ("https://fastapi.tiangolo.com/", None),
-    "pydantic": (
-    "https://docs.pydantic.dev/latest/",
-    "https://pydantic.dev/docs/validation/latest/objects.inv",
-),
+    "pydantic": ("https://docs.pydantic.dev/latest/", None),
 }
 
 intersphinx_disabled_domains = ["std"]

--- a/docs/usage/annotations.rst
+++ b/docs/usage/annotations.rst
@@ -89,25 +89,24 @@ In this case, the classical array is not represented as an `@leqo.input` qubit r
 Instead, it is used by the backend during snippet generation.
 The generated quantum register is marked with `@leqo.output` so that the prepared state can be passed to following nodes in the model.
 
-The amplitude encoding follow the existing annotation model by exposing the prepared register as a linking output.
+The encode-value handlers follow the existing annotation model by exposing the generated register as a linking output.
 
 
 
 
 .. list-table:: Encode-value handlers and generated outputs
-    :header-rows: 1
-    :widths: 25 35 40
+   :header-rows: 1
+   :widths: 25 35 40
 
-* * Handler
-  * Classical input
-  * Generated quantum output
-* * Amplitude encoding
-  * Constant array interpreted as an amplitude vector
-  * State-preparation circuit generated with Qiskit `StatePreparation` and exposed as `@leqo.output`
-* * Matrix encoding
-  * Constant flat array interpreted as a unitary matrix
-  * Unitary operation generated with Qiskit `UnitaryGate` and exposed as `@leqo.output`
-
+   * - Handler
+     - Classical input
+     - Generated quantum output
+   * - Amplitude encoding
+     - Constant array interpreted as an amplitude vector
+     - State-preparation circuit generated with Qiskit ``StatePreparation`` and exposed as ``@leqo.output``
+   * - Matrix encoding
+     - Constant flat array interpreted as a unitary matrix
+     - Unitary operation generated with Qiskit ``UnitaryGate`` and exposed as ``@leqo.output``
 
 Input
 -----

--- a/docs/usage/annotations.rst
+++ b/docs/usage/annotations.rst
@@ -76,34 +76,41 @@ Annotations can be emulated in openqasm2 by using special comments.
 
 
 
-Generated Encode-Value Snippets
--------------------------------
+Generated Enrichment Outputs
+----------------------------
 
-Some backend enrichments generate OpenQASM snippets from classical values rather than from already existing input qubits.
-Amplitude encoding and matrix encoding are examples of this case.
-The amplitude encoding handler accepts a constant classical array, generates a quantum state-preparation circuit from this array, and exposes the generated quantum register as an output of the snippet.
-The matrix encoding handler accepts a constant flat array, interprets it as a unitary matrix, generates a corresponding unitary operation, and also exposes the generated quantum register as an output of the snippet.
+Some enrichments generate OpenQASM snippets from model-level properties or classical values instead of using already existing input qubits.
+This applies to angle encoding, amplitude encoding, matrix encoding, encode-value handling, and selected measurement-related enrichments.
 
-In these cases, the classical array is not represented as an ``@leqo.input`` qubit register.
-Instead, it is used by the backend during snippet generation.
-The generated quantum register is marked with ``@leqo.output`` so that the prepared or transformed state can be passed to following nodes in the model.
+For angle encoding, the backend receives classical scalar or array values and generates rotation-based encoding operations.
+For amplitude encoding, the backend receives a classical array, interprets it as an amplitude vector, and generates a state-preparation circuit.
+For matrix encoding, the backend receives a flat classical array, interprets it as a unitary matrix, and generates the corresponding unitary operation.
 
-The encode-value handlers follow the existing annotation model by exposing the generated register as a linking output.
-They do not introduce a separate ancilla-management mechanism or new uncomputation logic.
+In these cases, the classical input is only used during backend generation and is not represented as an ``@leqo.input`` qubit register.
+The generated quantum register is exposed with ``@leqo.output`` so that the result can be passed to following nodes.
 
-.. list-table:: Encode-value handlers and generated outputs
+For measurement-related enrichments, additional basis-change operations may be generated when the measurement basis differs from the default computational basis.
+
+
+.. list-table:: Generated enrichment outputs and metadata
    :header-rows: 1
    :widths: 25 35 40
 
-   * - Handler
-     - Classical input
-     - Generated quantum output
+   * - Enrichment
+     - Model-level input
+     - Generated output or metadata
+   * - Angle encoding
+     - Classical scalar or array values
+     - Rotation-based encoding operations exposed through the generated output register
    * - Amplitude encoding
-     - Constant array interpreted as an amplitude vector
-     - State-preparation circuit generated with Qiskit ``StatePreparation`` and exposed as ``@leqo.output``
+     - Classical array interpreted as an amplitude vector
+     - State-preparation circuit exposed as ``@leqo.output``
    * - Matrix encoding
-     - Constant flat array interpreted as a unitary matrix
-     - Unitary operation generated with Qiskit ``UnitaryGate`` and exposed as ``@leqo.output``
+     - Flat classical array interpreted as a unitary matrix
+     - Generated unitary operation exposed as ``@leqo.output``
+   * - Measurement basis
+     - Measurement basis selected in the model
+     - Generated measurement structure with required basis-change operations
 
 .. _input-anker:
 

--- a/tests/enricher/test_quantum_comparison_predicates.py
+++ b/tests/enricher/test_quantum_comparison_predicates.py
@@ -1,0 +1,146 @@
+import pytest
+from openqasm3.ast import QuantumGate
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from app.enricher import Constraints
+from app.enricher.operator import OperatorEnricherStrategy
+from app.model.CompileRequest import OperatorNode
+from app.model.data_types import FloatType, QubitType
+from app.model.exceptions import (
+    InputCountMismatch,
+    InputSizeMismatch,
+    InputTypeMismatch,
+)
+
+EXPECTED_WIDTH = 3
+SINGLE_QUBIT_SIZE = 1
+INVALID_REGISTER_SIZE = 2
+
+
+def _only_quantum_gates(statements: list[object]) -> list[QuantumGate]:
+    return [stmt for stmt in statements if isinstance(stmt, QuantumGate)]
+
+
+@pytest.mark.parametrize(
+    ("operator", "expected_gates", "expected_depth"),
+    [
+        ("==", ["x", "cx", "cx"], 3),
+        ("!=", ["cx", "cx"], 2),
+        ("<", ["x", "ccx", "x"], 3),
+        (">", ["x", "ccx", "x"], 3),
+        ("<=", ["x", "x", "ccx", "x"], 4),
+        (">=", ["x", "x", "ccx", "x"], 4),
+    ],
+)
+@pytest.mark.asyncio
+async def test_dynamic_quantum_comparison_predicates_generate_expected_gates(
+    engine: AsyncEngine,
+    operator: str,
+    expected_gates: list[str],
+    expected_depth: int,
+) -> None:
+    node = OperatorNode(id="cmp_1", type="operator", operator=operator)
+    constraints = Constraints(
+        requested_inputs={
+            0: QubitType(size=SINGLE_QUBIT_SIZE),
+            1: QubitType(size=SINGLE_QUBIT_SIZE),
+        },
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+    results = await strategy._enrich_impl(node, constraints)
+
+    assert len(results) == 1
+
+    result = results[0]
+    statements = result.enriched_node.implementation.statements
+    gates = _only_quantum_gates(statements)
+
+    assert result.meta_data.width == EXPECTED_WIDTH
+    assert result.meta_data.depth == expected_depth
+    assert [gate.name.name for gate in gates] == expected_gates
+
+
+@pytest.mark.parametrize("operator", ["==", "!=", "<", ">", "<=", ">="])
+@pytest.mark.asyncio
+async def test_dynamic_quantum_comparison_predicates_require_constraints(
+    engine: AsyncEngine,
+    operator: str,
+) -> None:
+    node = OperatorNode(id="cmp_1", type="operator", operator=operator)
+    strategy = OperatorEnricherStrategy(engine)
+
+    with pytest.raises(InputCountMismatch):
+        await strategy._enrich_impl(node, None)
+
+
+@pytest.mark.parametrize("operator", ["==", "!=", "<", ">", "<=", ">="])
+def test_dynamic_quantum_comparison_predicates_require_two_inputs(
+    engine: AsyncEngine,
+    operator: str,
+) -> None:
+    node = OperatorNode(id="cmp_1", type="operator", operator=operator)
+    constraints = Constraints(
+        requested_inputs={0: QubitType(size=SINGLE_QUBIT_SIZE)},
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+
+    with pytest.raises(InputCountMismatch):
+        strategy._generate_comparison_enrichment(node, constraints)
+
+
+@pytest.mark.parametrize("operator", ["==", "!=", "<", ">", "<=", ">="])
+def test_dynamic_quantum_comparison_predicates_require_qubit_inputs(
+    engine: AsyncEngine,
+    operator: str,
+) -> None:
+    node = OperatorNode(id="cmp_1", type="operator", operator=operator)
+    constraints = Constraints(
+        requested_inputs={
+            0: QubitType(size=SINGLE_QUBIT_SIZE),
+            1: FloatType(size=32),
+        },
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+
+    with pytest.raises(InputTypeMismatch):
+        strategy._generate_comparison_enrichment(node, constraints)
+
+
+@pytest.mark.parametrize("operator", ["==", "!=", "<", ">", "<=", ">="])
+def test_dynamic_quantum_comparison_predicates_reject_multi_qubit_registers(
+    engine: AsyncEngine,
+    operator: str,
+) -> None:
+    node = OperatorNode(id="cmp_1", type="operator", operator=operator)
+    constraints = Constraints(
+        requested_inputs={
+            0: QubitType(size=INVALID_REGISTER_SIZE),
+            1: QubitType(size=SINGLE_QUBIT_SIZE),
+        },
+        requested_input_values={},
+    )
+
+    strategy = OperatorEnricherStrategy(engine)
+
+    with pytest.raises(InputSizeMismatch):
+        strategy._generate_comparison_enrichment(node, constraints)
+
+
+def test_dynamic_quantum_comparison_rejects_unknown_predicate(
+    engine: AsyncEngine,
+) -> None:
+    strategy = OperatorEnricherStrategy(engine)
+
+    with pytest.raises(ValueError, match="Unsupported comparison operator"):
+        strategy._comparison_gates(
+            "===",
+            strategy._qubit_reference("lhs", None),
+            strategy._qubit_reference("rhs", None),
+            strategy._qubit_reference("result", None),
+        )


### PR DESCRIPTION
Adds single-qubit support for !=, <, >, <=, and >= based on the existing equality enrichment. Includes tests for generated gates, invalid inputs, and unsupported predicates.

# Definition of Done

- [ ] **Code Completion**: All necessary code for the feature or bug fix has been written.
- [ ] **Testing**: Relevant tests (unit, integration, user acceptance) have passed.
- [ ] **Peer Review**: The code has undergone peer review by another team member.
- [ ] **Documentation**: Required documentation, such as comments and API documentation, is complete.
- [ ] **Deployment Readiness**: The work is ready for deployment to production if needed.
